### PR TITLE
Bugfix in express config. Static files are now loaded properly

### DIFF
--- a/webpack/server.js
+++ b/webpack/server.js
@@ -19,6 +19,8 @@ app.use(devMiddleware(compiler, {
 
 app.use(hotMiddleware(compiler));
 
+app.use(express.static(path.join(__dirname, '..', 'public')));
+
 app.get('*', (req, res) => {
     res.sendFile(path.join(__dirname, '..', 'public', 'index.html'));
 });


### PR DESCRIPTION
The previous setup loaded "index.html" no matter what path you visited. E.g. ask for `img/user.svg` -> get `index.html`.
