### PR TITLE
[Doppins] Upgrade dependency babel-core to 6.10.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "autoprefixer": "6.3.6",
     "babel-cli": "6.10.1",
-    "babel-core": "6.9.1",
+    "babel-core": "6.10.4",
     "babel-loader": "6.2.4",
     "babel-plugin-transform-object-rest-spread": "6.8.0",
     "babel-preset-es2015": "6.9.0",


### PR DESCRIPTION
Hi!

A new version was just released of `babel-core`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded babel-core from `6.9.1` to `6.10.4`
