### PR TITLE
[Doppins] Upgrade dependency webdriverio to 4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "wdio-junit-reporter": "0.1.0",
     "wdio-sauce-service": "0.2.2",
     "wdio-selenium-standalone-service": "0.0.5",
-    "webdriverio": "4.0.9",
+    "webdriverio": "4.1.0",
     "webpack": "1.13.1",
     "webpack-dev-middleware": "1.6.1",
     "webpack-hot-middleware": "2.10.0"


### PR DESCRIPTION
Hi!

A new version was just released of `webdriverio`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded webdriverio from `4.0.9` to `4.1.0`
