### PR TITLE
[Doppins] Upgrade dependency semantic-ui-css to 2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,6 @@
     "react-router": "2.5.1",
     "redux": "3.5.2",
     "redux-form": "5.2.5",
-    "semantic-ui-css": "2.1.8"
+    "semantic-ui-css": "2.2.1"
   }
 }


### PR DESCRIPTION
Hi!

A new version was just released of `semantic-ui-css`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded semantic-ui-css from `2.1.8` to `2.2.1`
#### Changelog:
#### Version 2.2.1

**Bugs**
- **Dropdown** - Fixed issue where using both `<select>` and `allowAdditions: true` would cause dropdown selection to fail
