### PR TITLE
[Doppins] Upgrade dependency selenium-standalone to ~5.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "phantomjs-prebuilt": "2.1.7",
     "postcss-loader": "0.9.1",
     "sass-loader": "3.2.1",
-    "selenium-standalone": "5.1.1",
+    "selenium-standalone": "5.2.0",
     "source-map-loader": "0.1.5",
     "style-loader": "0.13.1",
     "wd-selenium-hooks": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "style-loader": "0.13.1",
     "wd-selenium-hooks": "0.1.0",
     "wdio": "0.3.1",
-    "wdio-cucumber-framework": "0.1.0",
+    "selenium-standalone": "~5.4.0",
     "wdio-junit-reporter": "0.1.0",
     "wdio-sauce-service": "0.2.2",
     "wdio-selenium-standalone-service": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "phantomjs-prebuilt": "2.1.7",
     "postcss-loader": "0.9.1",
     "sass-loader": "3.2.1",
-    "selenium-standalone": "5.2.0",
+    "selenium-standalone": "5.3.0",
     "source-map-loader": "0.1.5",
     "style-loader": "0.13.1",
     "wd-selenium-hooks": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "phantomjs-prebuilt": "2.1.7",
     "postcss-loader": "0.9.1",
     "sass-loader": "3.2.1",
-    "selenium-standalone": "5.3.0",
+    "selenium-standalone": "5.3.1",
     "source-map-loader": "0.1.5",
     "style-loader": "0.13.1",
     "wd-selenium-hooks": "0.1.0",


### PR DESCRIPTION
Hi!

A new version was just released of `selenium-standalone`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded selenium-standalone from `5.1.1` to `5.2.0`
