### PR TITLE
[Doppins] Upgrade dependency webpack-hot-middleware to 2.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "webdriverio": "4.1.0",
     "webpack": "1.13.1",
     "webpack-dev-middleware": "1.6.1",
-    "webpack-hot-middleware": "2.11.0"
+    "webpack-hot-middleware": "2.12.0"
   },
   "dependencies": {
     "axios": "0.12.0",


### PR DESCRIPTION
Hi!

A new version was just released of `webpack-hot-middleware`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded webpack-hot-middleware from `2.11.0` to `2.12.0`
