### PR TITLE
[Doppins] Upgrade dependency normalize.css to 4.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "express": "4.14.0",
     "lodash": "4.13.1",
     "moment": "2.13.0",
-    "normalize.css": "4.1.1",
+    "normalize.css": "4.2.0",
     "react": "15.1.0",
     "react-datepicker": "0.27.0",
     "react-dom": "15.1.0",


### PR DESCRIPTION
Hi!

A new version was just released of `normalize.css`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded normalize.css from `4.1.1` to `4.2.0`
