### PR TITLE
[Doppins] Upgrade dependency eslint to ~3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "chai-as-promised": "~5.3.0",
     "css-loader": "~0.23.1",
     "cucumber": "~0.10.2",
-    "eslint": "~2.13.1",
+    "eslint": "~3.0.0",
     "eslint-config-airbnb": "~9.0.1",
     "eslint-plugin-import": "~1.9.2",
     "eslint-plugin-jsx-a11y": "~1.5.3",


### PR DESCRIPTION
Hi!

A new version was just released of `eslint`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded eslint from `~2.13.1` to `~3.0.0`
