### PR TITLE
[Doppins] Upgrade dependency react-router to 2.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "react-datepicker": "0.27.0",
     "react-dom": "15.1.0",
     "react-redux": "4.4.5",
-    "react-router": "2.5.1",
+    "react-router": "2.5.2",
     "redux": "3.5.2",
     "redux-form": "5.3.0",
     "semantic-ui-css": "2.2.1"


### PR DESCRIPTION
Hi!

A new version was just released of `react-router`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded react-router from `2.5.1` to `2.5.2`
