### PR TITLE
[Doppins] Upgrade dependency react-dom to 15.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "normalize.css": "4.2.0",
     "react": "15.1.0",
     "react-datepicker": "0.27.0",
-    "react-dom": "15.1.0",
+    "react-dom": "15.2.0",
     "react-redux": "4.4.5",
     "react-router": "2.5.1",
     "redux": "3.5.2",


### PR DESCRIPTION
Hi!

A new version was just released of `react-dom`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded react-dom from `15.1.0` to `15.2.0`
