### PR TITLE
[Doppins] Upgrade dependency html-webpack-plugin to ~2.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "express": "~4.14.0",
     "extract-text-webpack-plugin": "~1.0.1",
     "file-loader": "~0.9.0",
-    "html-webpack-plugin": "~2.21.0",
+    "html-webpack-plugin": "~2.22.0",
     "http-proxy-middleware": "~0.16.0",
     "node-libs-browser": "~1.0.0",
     "node-sass": "~3.8.0",


### PR DESCRIPTION
Hi!

A new version was just released of `html-webpack-plugin`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded html-webpack-plugin from `~2.21.0` to `~2.22.0`
