### PR TITLE
[Doppins] Upgrade dependency react-datepicker to 0.28.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "moment": "2.13.0",
     "normalize.css": "4.2.0",
     "react": "15.1.0",
-    "react-datepicker": "0.27.0",
+    "react-datepicker": "0.28.0",
     "react-dom": "15.1.0",
     "react-redux": "4.4.5",
     "react-router": "2.5.1",


### PR DESCRIPTION
Hi!

A new version was just released of `react-datepicker`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded react-datepicker from `0.27.0` to `0.28.0`
