### PR TITLE
[Doppins] Upgrade dependency http-proxy-middleware to ~0.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "extract-text-webpack-plugin": "~1.0.1",
     "file-loader": "~0.9.0",
     "html-webpack-plugin": "~2.21.0",
-    "http-proxy-middleware": "~0.16.0",
+    "http-proxy-middleware": "~0.17.0",
     "node-libs-browser": "~1.0.0",
     "node-sass": "~3.8.0",
     "object-assign": "~4.1.0",


### PR DESCRIPTION
Hi!

A new version was just released of `http-proxy-middleware`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded http-proxy-middleware from `~0.16.0` to `~0.17.0`
#### Changelog:
#### Version 0.17.0

`https://github.com/chimurai/http-proxy-middleware/compare/v0.16.0...v0.17.0`
- fix(context matching): Use [RFC 3986 path](https://tools.ietf.org/html/rfc3986#section-3.3) in context matching. (excludes query parameters) (`https://github.com/chimurai/http-proxy-middleware/commit/8fe60080d2dd91e063913600896cc08424967336`)
