### PR TITLE
[Doppins] Upgrade dependency moment to 2.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "dependencies": {
     "axios": "0.12.0",
     "lodash": "4.13.1",
-    "moment": "2.14.0",
+    "moment": "2.14.1",
     "normalize.css": "4.2.0",
     "react": "15.1.0",
     "react-datepicker": "0.27.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "dependencies": {
     "axios": "0.12.0",
     "lodash": "4.13.1",
-    "moment": "2.13.0",
+    "moment": "2.14.0",
     "normalize.css": "4.2.0",
     "react": "15.1.0",
     "react-datepicker": "0.27.0",


### PR DESCRIPTION
Hi!

A new version was just released of `moment`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded moment from `2.13.0` to `2.14.0`
