### PR TITLE
[Doppins] Upgrade dependency eslint to ~3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "chai-as-promised": "~5.3.0",
     "css-loader": "~0.23.1",
     "cucumber": "~0.10.2",
-    "eslint": "~2.13.1",
+    "eslint": "~3.0.1",
     "eslint-config-airbnb": "~9.0.1",
     "eslint-plugin-import": "~1.9.2",
     "eslint-plugin-jsx-a11y": "~1.5.3",


### PR DESCRIPTION
Hi!

A new version was just released of `eslint`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded eslint from `~2.13.1` to `~3.0.1`
#### Changelog:
#### Version 3.0.0
- 66de9d8 Docs: Update installation instructions on README (`#6569`) (Nicholas C. Zakas)
- dc5b78b Breaking: Add `require-yield` rule to `eslint:recommended` (fixes `#6550`) (`#6554`) (Gyandeep Singh)
- 7988427 Fix: lib/config.js tests pass if personal config exists (fixes `#6559`) (`#6566`) (Kevin Partington)
- 4c05967 Docs: Update rule docs for new format (fixes `#5417`) (`#6551`) (Nicholas C. Zakas)
- 70da5a8 Docs: Correct link to rules page (#fixes 6553) (`#6561`) (alberto)
- e2b2030 Update: Check RegExp strings for `no-regex-spaces` (fixes `#3586`) (`#6379`) (Jackson Ray Hamilton)
- 397e51b Update: Implement outerIIFEBody for indent rule (fixes `#6259`) (`#6382`) (David Shepherd)
- 666da7c Docs: 3.0.0 migration guide (`#6521`) (Nicholas C. Zakas)
- b9bf8fb Docs: Update Governance Policy (fixes `#6452`) (`#6522`) (Nicholas C. Zakas)
- 1290657 Update: `no-unused-vars` ignores read it modifies itself (fixes `#6348`) (`#6535`) (Toru Nagashima)
- d601f6b Fix: Delete cache only when executing on files (fixes `#6459`) (`#6540`) (Kai Cataldo)
- e0d4b19 Breaking: Error thrown/printed if no config found (fixes `#5987`) (`#6538`) (Kevin Partington)
- 18663d4 Fix: false negative of `no-useless-rename` (fixes `#6502`) (`#6506`) (Toru Nagashima)
- 0a7936d Update: Add fixer for prefer-const (fixes `#6448`) (`#6486`) (Nick Heiner)
- c60341f Chore: Update index and `meta` for `"eslint:recommended"` (refs `#6403`) (`#6539`) (Mark Pedrotti)
- 73da28d Better wording for the error reported by the rule "no-else-return" `#6411` (`#6413`) (Olivier Thomann)
- e06a5b5 Update: Add fixer for arrow-parens (fixes `#4766`) (`#6501`) (madmed88)
- 5f8f3e8 Docs: Remove Box as a sponsor (`#6529`) (Nicholas C. Zakas)
- 7dfe0ad Docs: fix max-lines samples (fixes `#6516`) (`#6515`) (Dmitriy Shekhovtsov)
- fa05119 Breaking: Update eslint:recommended (fixes `#6403`) (`#6509`) (Nicholas C. Zakas)
- e96177b Docs: Add "Proposing a Rule Change" link to CONTRIBUTING.md (`#6511`) (Kevin Partington)
- bea9096 Docs: Update pull request steps (fixes `#6474`) (`#6510`) (Nicholas C. Zakas)
- 7bcf6e0 Docs: Consistent example headings & text pt3 (refs `#5446`) (`#6492`) (Guy Fraser)
- 1a328d9 Docs: Consistent example headings & text pt4 (refs `#5446`) (`#6493`) (Guy Fraser)
- ff5765e Docs: Consistent example headings & text pt2 (refs `#5446`)(`#6491`) (Guy Fraser)
- 01384fa Docs: Fixing typos (refs `#5446`)(`#6494`) (Guy Fraser)
- 4343ae8 Fix: false negative of `object-shorthand` (fixes `#6429`) (`#6434`) (Toru Nagashima)
- b7d8c7d Docs: more accurate yoda-speak (`#6497`) (Tony Lukasavage)
- 3b0ab0d Fix: add warnIgnored flag to CLIEngine.executeOnText (fixes `#6302`) (`#6305`) (Robert Levy)
- c2c6cec Docs: Mark object-shorthand as fixable. (`#6485`) (Nick Heiner)
- 5668236 Fix: Allow objectsInObjects exception when destructuring (fixes `#6469`) (`#6470`) (Adam Renklint)
- 17ac0ae Fix: `strict` rule reports a syntax error for ES2016 (fixes `#6405`) (`#6464`) (Toru Nagashima)
- 4545123 Docs: Rephrase documentation for `no-duplicate-imports` (`#6463`) (Simen Bekkhus)
- 1b133e3 Docs: improve `no-native-reassign` and specifying globals (fixes `#5358`) (`#6462`) (Toru Nagashima)
- b179373 Chore: Remove dead code in excuteOnFiles (fixes `#6467`) (`#6466`) (Andrew Hutchings)
- 18fbc4b Chore: Simplify eslint process exit code (fixes `#6368`) (`#6371`) (alberto)
- 58542e4 Breaking: Drop support for node < 4 (fixes `#4483`) (`#6401`) (alberto)
- f50657e Breaking: use default for complexity in eslint:recommended (fixes `#6021`) (`#6410`) (alberto)
- 3e690fb Fix: Exit init early if guide is chosen w/ no package.json (fixes `#6476`) (`#6478`) (Kai Cataldo)
