### PR TITLE
[Doppins] Upgrade dependency cucumber to ~1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "chai": "~3.5.0",
     "chai-as-promised": "~5.3.0",
     "css-loader": "~0.23.1",
-    "cucumber": "~0.10.2",
+    "cucumber": "~1.2.1",
     "eslint": "~2.13.1",
     "eslint-config-airbnb": "~9.0.1",
     "eslint-plugin-import": "~1.9.2",


### PR DESCRIPTION
Hi!

A new version was just released of `cucumber`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded cucumber from `~0.10.2` to `~1.2.1`
