### PR TITLE
[Doppins] Upgrade dependency selenium-standalone to ~5.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "redux-devtools-dock-monitor": "~1.1.1",
     "redux-devtools-log-monitor": "~1.0.11",
     "sass-loader": "~4.0.0",
-    "selenium-standalone": "~5.4.1",
+    "selenium-standalone": "~5.5.0",
     "source-map-loader": "~0.1.5",
     "style-loader": "~0.13.1",
     "url-loader": "~0.5.7",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "redux-devtools-dock-monitor": "~1.1.1",
     "redux-devtools-log-monitor": "~1.0.11",
     "sass-loader": "~4.0.0",
-    "selenium-standalone": "~5.3.1",
+    "selenium-standalone": "~5.4.1",
     "source-map-loader": "~0.1.5",
     "style-loader": "~0.13.1",
     "url-loader": "~0.5.7",


### PR DESCRIPTION
Hi!

A new version was just released of `selenium-standalone`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded selenium-standalone from `~5.3.1` to `~5.4.1`
