### PR TITLE
[Doppins] Upgrade dependency react-datepicker to 0.28.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "normalize.css": "4.2.0",
     "react": "15.1.0",
     "react-breadcrumbs": "^1.3.15",
-    "react-datepicker": "0.27.0",
+    "react-datepicker": "0.28.1",
     "react-dom": "15.1.0",
     "react-notification-system": "~0.2.7",
     "react-redux": "4.4.5",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "normalize.css": "4.2.0",
     "react": "15.1.0",
     "react-breadcrumbs": "^1.3.15",
-    "react-datepicker": "0.28.1",
+    "react-datepicker": "0.28.2",
     "react-dom": "15.1.0",
     "react-notification-system": "~0.2.7",
     "react-redux": "4.4.5",


### PR DESCRIPTION
Hi!

A new version was just released of `react-datepicker`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded react-datepicker from `0.27.0` to `0.28.1`
#### Changelog:
#### Version 0.28.1

Fix unknown prop warning that was introduced in React v15.2
#### Version 0.28.0
- Ability to inline the calendar
- Add openToDate prop
- Support autoComplete prop
