### PR TITLE
[Doppins] Upgrade dependency axios to 0.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "webpack-hot-middleware": "~2.12.0"
   },
   "dependencies": {
-    "axios": "0.12.0",
+    "axios": "0.13.0",
     "lodash": "4.13.1",
     "moment": "2.13.0",
     "normalize.css": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "webpack-hot-middleware": "~2.12.0"
   },
   "dependencies": {
-    "axios": "0.13.0",
+    "axios": "0.13.1",
     "lodash": "4.13.1",
     "moment": "2.13.0",
     "normalize.css": "4.2.0",


### PR DESCRIPTION
Hi!

A new version was just released of `axios`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded axios from `0.12.0` to `0.13.0`
