### PR TITLE
[Doppins] Upgrade dependency eslint-plugin-import to ~1.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "cucumber": "~0.10.2",
     "eslint": "~2.13.1",
     "eslint-config-airbnb": "~9.0.1",
-    "eslint-plugin-import": "~1.9.2",
+    "eslint-plugin-import": "~1.10.3",
     "eslint-plugin-jsx-a11y": "~1.5.3",
     "eslint-plugin-react": "~5.2.2",
     "express": "~4.14.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "cucumber": "~0.10.2",
     "eslint": "~2.13.1",
     "eslint-config-airbnb": "~9.0.1",
-    "eslint-plugin-import": "~1.11.0",
+    "eslint-plugin-import": "~1.11.1",
     "eslint-plugin-jsx-a11y": "~1.5.3",
     "eslint-plugin-react": "~5.2.2",
     "express": "~4.14.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "cucumber": "~0.10.2",
     "eslint": "~2.13.1",
     "eslint-config-airbnb": "~9.0.1",
-    "eslint-plugin-import": "~1.11.1",
+    "eslint-plugin-import": "~1.12.0",
     "eslint-plugin-jsx-a11y": "~1.5.3",
     "eslint-plugin-react": "~5.2.2",
     "express": "~4.14.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "cucumber": "~0.10.2",
     "eslint": "~2.13.1",
     "eslint-config-airbnb": "~9.0.1",
-    "eslint-plugin-import": "~1.10.3",
+    "eslint-plugin-import": "~1.11.0",
     "eslint-plugin-jsx-a11y": "~1.5.3",
     "eslint-plugin-react": "~5.2.2",
     "express": "~4.14.0",


### PR DESCRIPTION
Hi!

A new version was just released of `eslint-plugin-import`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded eslint-plugin-import from `~1.9.2` to `~1.10.3`
