### PR TITLE
[Doppins] Upgrade dependency react-router to 2.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "react-notification-system": "~0.2.7",
     "react-redux": "4.4.5",
     "react-router": "2.6.0",
-    "redux": "3.5.2",
+    "react-router": "2.6.1",
     "redux-form": "5.3.1",
     "redux-thunk": "^2.1.0",
     "semantic-ui-css": "2.2.1"

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "react-dom": "15.1.0",
     "react-notification-system": "~0.2.7",
     "react-redux": "4.4.5",
-    "react-router": "2.5.2",
+    "react-router": "2.6.0",
     "redux": "3.5.2",
     "redux-form": "5.3.1",
     "redux-thunk": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "react-dom": "15.1.0",
     "react-notification-system": "~0.2.7",
     "react-redux": "4.4.5",
-    "react-router": "0.13.6",
+    "react-router": "2.5.2",
     "redux": "3.5.2",
     "redux-form": "5.3.1",
     "redux-thunk": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "react-dom": "15.1.0",
     "react-notification-system": "~0.2.7",
     "react-redux": "4.4.5",
-    "react-router": "2.5.1",
+    "react-router": "0.13.6",
     "redux": "3.5.2",
     "redux-form": "5.3.1",
     "redux-thunk": "^2.1.0",


### PR DESCRIPTION
Hi!

A new version was just released of `react-router`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded react-router from `2.5.1` to `0.13.6`
