### PR TITLE
[Doppins] Upgrade dependency lodash to 4.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   },
   "dependencies": {
     "axios": "0.12.0",
-    "lodash": "4.13.1",
+    "lodash": "4.14.0",
     "moment": "2.13.0",
     "normalize.css": "4.2.0",
     "react": "15.1.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   "dependencies": {
     "axios": "0.12.0",
     "lodash": "4.14.0",
-    "moment": "2.13.0",
+    "lodash": "4.14.1",
     "normalize.css": "4.2.0",
     "react": "15.1.0",
     "react-breadcrumbs": "^1.3.15",


### PR DESCRIPTION
Hi!

A new version was just released of `lodash`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded lodash from `4.13.1` to `4.14.0`
