### PR TITLE
[Doppins] Upgrade dependency eslint-config-airbnb to ~10.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "css-loader": "~0.23.1",
     "cucumber": "~0.10.2",
     "eslint": "~2.13.1",
-    "eslint-config-airbnb": "~9.0.1",
+    "eslint-config-airbnb": "~10.0.0",
     "eslint-plugin-import": "~1.9.2",
     "eslint-plugin-jsx-a11y": "~1.5.3",
     "eslint-plugin-react": "~5.2.2",


### PR DESCRIPTION
Hi!

A new version was just released of `eslint-config-airbnb`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded eslint-config-airbnb from `~9.0.1` to `~10.0.0`
