### PR TITLE
Add terms to profile and validate account before trip signup

### DIFF
--- a/src/actions/authenticationActions.js
+++ b/src/actions/authenticationActions.js
@@ -98,7 +98,7 @@ export const setPassword = (data, headers) => dispatch => {
     return axios(config)
         .then(res => {
             localStorage.setItem('jwt', res.data.jwt);
-            browserHistory.push('/');
+            browserHistory.push('/profile');
             return dispatch(receiveLogin(res.data));
         })
         .catch(err => dispatch(loginError(err.data.message)));

--- a/src/commons/Form/ToggleField.jsx
+++ b/src/commons/Form/ToggleField.jsx
@@ -7,7 +7,7 @@ import React, { PropTypes } from 'react';
 *
 * name - string: Name for toggle, placed above it.
 *
-* label - string: Label for toggle, placed to the right of the toggle.
+* label - string: Label for toggle, placed to the right of the toggle. It allows HTML.
 *
 * children - object: A redux form object.
 *
@@ -22,7 +22,7 @@ const ToggleField = props => (
                 type="checkbox"
                 id={props.id}
             />
-            <label>{props.label}</label>
+            <label dangerouslySetInnerHTML={{ __html: props.label }} />
         </div>
     </div>
 );

--- a/src/commons/user/editUser.jsx
+++ b/src/commons/user/editUser.jsx
@@ -123,7 +123,7 @@ function EditUser(props) {
                 <Button
                     type="submit"
                     color="green"
-                    right
+                    fluid
                     disabled={isFetching}
                     loading={isFetching}
                     id="submit"

--- a/src/commons/user/editUser.jsx
+++ b/src/commons/user/editUser.jsx
@@ -7,10 +7,13 @@ import DateField from '../Form/DateField';
 import InputField from '../Form/InputField';
 import SelectField from '../Form/SelectField';
 import TextField from '../Form/TextField';
+import ToggleFIeld from '../Form/ToggleField';
 import { USER_ROLES } from '../../constants';
 import { emailIsValid } from '../../helpers';
 
-const fields = ['firstname', 'lastname', 'email', 'role', 'birth', 'notes', 'volunteerInfo'];
+const fields = [
+    'firstname', 'lastname', 'email', 'role', 'birth', 'notes', 'volunteerInfo', 'readTerms'
+];
 
 const validate = values => {
     const errors = {};
@@ -34,16 +37,16 @@ const validate = values => {
     return errors;
 };
 
-const renderIfAdmin = (props, element) => {
+const renderIfAdmin = (props, elementForAdmin, elementForUser) => {
     if (props.showAdminFields) {
-        return element;
+        return elementForAdmin;
     }
-    return '';
+    return elementForUser || '';
 };
 
 function EditUser(props) {
     const {
-        fields: { firstname, lastname, email, role, birth, notes, volunteerInfo },
+        fields: { firstname, lastname, email, role, birth, notes, volunteerInfo, readTerms },
         handleSubmit,
         errorMessage,
         isFetching
@@ -93,6 +96,28 @@ function EditUser(props) {
                     <TextField rows={3} label="Notes (only seen by administrators)">
                         {notes}
                     </TextField>
+                )}
+
+                {renderIfAdmin(props,
+                    <ToggleFIeld
+                        name="Guidelines for A Drop in the Ocean"
+                        label={`User confirmation of reading the guidelines.
+                        <a target="_blank" href="http://www.drapenihavet.no/wp-content/uploads/2016/07/Guidelines-for-volunteer-workers-July.16.pdf">
+                        Click here to read the guidelines</a>.`}
+                        id="readTerms"
+                    >
+                        {readTerms}
+                    </ToggleFIeld>
+                ,
+                    <ToggleFIeld
+                        name="Guidelines for A Drop in the Ocean"
+                        label={`I confirm that I have read the guidelines for A Drop in the Ocean.
+                        <a target="_blank" href="http://www.drapenihavet.no/wp-content/uploads/2016/07/Guidelines-for-volunteer-workers-July.16.pdf">
+                        Click here to read the guidelines</a>.`}
+                        id="readTerms"
+                    >
+                        {readTerms}
+                    </ToggleFIeld>
                 )}
 
                 <Button

--- a/src/commons/user/editUser.jsx
+++ b/src/commons/user/editUser.jsx
@@ -102,7 +102,7 @@ function EditUser(props) {
                     <ToggleField
                         name="Guidelines for A Drop in the Ocean"
                         label={`User confirmation of reading the guidelines.
-                        <a target="_blank" href="http://www.drapenihavet.no/wp-content/uploads/2016/07/Guidelines-for-volunteer-workers-July.16.pdf">
+                        <a target="_blank" rel="noopener noreferrer" href="http://www.drapenihavet.no/wp-content/uploads/2016/07/Guidelines-for-volunteer-workers-July.16.pdf">
                         Click here to read the guidelines</a>.`}
                         id="readTerms"
                     >
@@ -112,7 +112,7 @@ function EditUser(props) {
                     <ToggleField
                         name="Guidelines for A Drop in the Ocean"
                         label={`I confirm that I have read the guidelines for A Drop in the Ocean.
-                        <a target="_blank" href="http://www.drapenihavet.no/wp-content/uploads/2016/07/Guidelines-for-volunteer-workers-July.16.pdf">
+                        <a target="_blank" rel="noopener noreferrer" href="http://www.drapenihavet.no/wp-content/uploads/2016/07/Guidelines-for-volunteer-workers-July.16.pdf">
                         Click here to read the guidelines</a>.`}
                         id="readTerms"
                     >

--- a/src/commons/user/editUser.jsx
+++ b/src/commons/user/editUser.jsx
@@ -7,7 +7,7 @@ import DateField from '../Form/DateField';
 import InputField from '../Form/InputField';
 import SelectField from '../Form/SelectField';
 import TextField from '../Form/TextField';
-import ToggleFIeld from '../Form/ToggleField';
+import ToggleField from '../Form/ToggleField';
 import { USER_ROLES } from '../../constants';
 import { emailIsValid } from '../../helpers';
 
@@ -99,7 +99,7 @@ function EditUser(props) {
                 )}
 
                 {renderIfAdmin(props,
-                    <ToggleFIeld
+                    <ToggleField
                         name="Guidelines for A Drop in the Ocean"
                         label={`User confirmation of reading the guidelines.
                         <a target="_blank" href="http://www.drapenihavet.no/wp-content/uploads/2016/07/Guidelines-for-volunteer-workers-July.16.pdf">
@@ -107,9 +107,9 @@ function EditUser(props) {
                         id="readTerms"
                     >
                         {readTerms}
-                    </ToggleFIeld>
+                    </ToggleField>
                 ,
-                    <ToggleFIeld
+                    <ToggleField
                         name="Guidelines for A Drop in the Ocean"
                         label={`I confirm that I have read the guidelines for A Drop in the Ocean.
                         <a target="_blank" href="http://www.drapenihavet.no/wp-content/uploads/2016/07/Guidelines-for-volunteer-workers-July.16.pdf">
@@ -117,7 +117,7 @@ function EditUser(props) {
                         id="readTerms"
                     >
                         {readTerms}
-                    </ToggleFIeld>
+                    </ToggleField>
                 )}
 
                 <Button

--- a/src/commons/user/viewUser.jsx
+++ b/src/commons/user/viewUser.jsx
@@ -60,6 +60,13 @@ const ViewUser = (props) => (
             content={props.user.volunteerInfo}
         />
         {renderIfAdmin(props,
+            <ListItem
+                name="Has the user confirmed that he/she has read the guidelines?"
+                icon="book"
+                content={props.user.readTerms ? 'Yes' : 'No'}
+            />
+        )}
+        {renderIfAdmin(props,
             <FluidListItem
                 name="Notes (only seen by administrators)"
                 icon="info circle"

--- a/src/sections/trips/signup/index.jsx
+++ b/src/sections/trips/signup/index.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes, Component } from 'react';
 import { connect } from 'react-redux';
+import { Link } from 'react-router';
 import SignupTripForm from './SignupTripForm';
 import Header from '../../../commons/pageHeader';
 import { create } from '../../../actions/tripActions';
@@ -28,12 +29,21 @@ class SignupTripFormContainer extends Component {
         this.handlers.list();
     }
 
+    userAllowedToSignUp() {
+        const account = this.props.account;
+        if (!account.readTerms || !account.firstname ||
+            !account.lastname || !account.birth || !account.volunteerInfo) {
+            return false;
+        }
+        return true;
+    }
+
     handleSubmit(data) {
         this.setState({
             isFetching: true
         });
         const trip = data;
-        trip.wishStartDate = data.startDate; // Cannot be null, but not used anymore
+        trip.wishStartDate = data.startDate; // Cannot be null. Field is not used anymore.
         this.handlers.create(trip)
             .then(response => {
                 let success = null;
@@ -50,6 +60,31 @@ class SignupTripFormContainer extends Component {
             });
     }
 
+    renderSignUpForTripForm() {
+        if (this.userAllowedToSignUp()) {
+            return (
+                <SignupTripForm
+                    destinations={this.props.destinations.filter(val => (val.isActive))}
+                    onSubmit={e => { this.handleSubmit(e); }}
+                    errorMessage={this.state.errorMessage}
+                    isFetching={this.state.isFetching}
+                    successMessage={this.state.successMessage}
+                />
+            );
+        }
+        return (
+            <div>
+                <h3>
+                    To register for a trip, you'll have to complete your profile.
+                </h3>
+                <h3>
+                    Go to <Link to="/profile/edit">your profile</Link> and
+                    add more information, then come back here.
+                </h3>
+            </div>
+        );
+    }
+
     render() {
         return (
             <div className="ui segments">
@@ -62,13 +97,7 @@ class SignupTripFormContainer extends Component {
                     />
                 </div>
                 <div className="ui blue segment">
-                    <SignupTripForm
-                        destinations={this.props.destinations.filter(val => (val.isActive))}
-                        onSubmit={e => { this.handleSubmit(e); }}
-                        errorMessage={this.state.errorMessage}
-                        isFetching={this.state.isFetching}
-                        successMessage={this.state.successMessage}
-                    />
+                    {this.renderSignUpForTripForm()}
                 </div>
             </div>
         );
@@ -76,12 +105,14 @@ class SignupTripFormContainer extends Component {
 }
 
 const mapStateToProps = store => ({
-    destinations: store.destinationState.destinations
+    destinations: store.destinationState.destinations,
+    account: store.accountState.account
 });
 
 SignupTripFormContainer.propTypes = {
     dispatch: PropTypes.func.isRequired,
-    destinations: PropTypes.array.isRequired
+    destinations: PropTypes.array.isRequired,
+    account: PropTypes.object.isRequired
 };
 
 export default connect(mapStateToProps)(SignupTripFormContainer);

--- a/src/sections/trips/signup/index.jsx
+++ b/src/sections/trips/signup/index.jsx
@@ -31,11 +31,8 @@ class SignupTripFormContainer extends Component {
 
     userAllowedToSignUp() {
         const account = this.props.account;
-        if (!account.readTerms || !account.firstname ||
-            !account.lastname || !account.birth || !account.volunteerInfo) {
-            return false;
-        }
-        return true;
+        return account.readTerms && account.firstname &&
+               account.lastname && account.birth && account.volunteerInfo;
     }
 
     handleSubmit(data) {


### PR DESCRIPTION
## At a glance
- Add toggle field to user profile and admin views
- Redirect user to `/profile` after completing sign up
- Validate user fields before letting user sign up for a trip
- Makes save button in edit form fluid, as users reported that they didn't see it during user tests
## Screenshots
### User

![image](https://cloud.githubusercontent.com/assets/1620267/17397657/5a043ff0-5a39-11e6-84a0-19687cc2ee1d.png)
![image](https://cloud.githubusercontent.com/assets/1620267/17398140/961a3902-5a3b-11e6-90f3-a6628cc554cd.png)
### Admin

![image](https://cloud.githubusercontent.com/assets/1620267/17398108/6835027e-5a3b-11e6-90a0-89ea57b4ddf1.png)
![image](https://cloud.githubusercontent.com/assets/1620267/17398079/469faeac-5a3b-11e6-8fec-90c6c09a259b.png)
## References

See [DIH-275](https://jira.capraconsulting.no/browse/DIH-275)
