### PR TITLE
Implement admin trip view

### DIFF
--- a/src/commons/adminTripTable/tripRequestsTable.jsx
+++ b/src/commons/adminTripTable/tripRequestsTable.jsx
@@ -45,7 +45,7 @@ class TripRequestsTable extends Component {
         return trips.map(trip => {
             const row = {
                 id: trip.id,
-                userId: trip.uiserId,
+                userId: trip.userId,
                 startDate: moment(trip.startDate).format('YYYY-MM-DD'),
                 endDate: trip.endDate ? moment(trip.endDate).format('YYYY-MM-DD') : 'Not set',
                 status: <TripStatusDropdown trip={trip} />
@@ -64,6 +64,29 @@ class TripRequestsTable extends Component {
         });
     }
 
+    linkKey() {
+        if (!this.props.userId) {
+            return 'userId';
+        }
+
+        return 'id';
+    }
+
+    linkElement() {
+        if (!this.props.userId) {
+            return {
+                columnName: 'firstname',
+                prefix: '/admin/users/',
+                suffix: '/trips'
+            };
+        }
+
+        return {
+            columnName: 'destination',
+            prefix: '/admin/trips/'
+        };
+    }
+
     render() {
         const trips = this.getTrips();
         const dateFields = { from: 'startDate', to: 'endDate' };
@@ -75,11 +98,8 @@ class TripRequestsTable extends Component {
                 columnNames={this.prepareTableHeaders()}
                 items={this.prepareTableContent(trips)}
                 itemKey="id"
-                linkKey="userId"
-                link={{
-                    columnName: 'firstname',
-                    prefix: '/admin/users/'
-                }}
+                linkKey={this.linkKey()}
+                link={this.linkElement()}
             />
         );
     }

--- a/src/commons/adminTripTable/tripsTable.jsx
+++ b/src/commons/adminTripTable/tripsTable.jsx
@@ -28,8 +28,7 @@ class TripRequestsTable extends Component {
     prepareTableHeaders() {
         const headers = {};
         if (!this.props.userId) {
-            headers.firstname = 'First name';
-            headers.lastname = 'Last name';
+            headers.fullName = 'Name';
         }
 
         if (!this.props.destinationId) {
@@ -58,8 +57,7 @@ class TripRequestsTable extends Component {
             };
 
             if (!this.props.userId) {
-                row.firstname = trip.user.firstname;
-                row.lastname = trip.user.lastname;
+                row.fullName = trip.user.fullName;
             }
 
             if (!this.props.destinationId) {
@@ -81,7 +79,7 @@ class TripRequestsTable extends Component {
     linkElement() {
         if (!this.props.userId) {
             return {
-                columnName: 'firstname',
+                columnName: 'fullName',
                 prefix: '/admin/users/',
                 suffix: '/trips'
             };

--- a/src/commons/adminTripTable/tripsTable.jsx
+++ b/src/commons/adminTripTable/tripsTable.jsx
@@ -68,14 +68,6 @@ class TripRequestsTable extends Component {
         });
     }
 
-    linkKey() {
-        if (!this.props.userId) {
-            return 'userId';
-        }
-
-        return 'id';
-    }
-
     linkElement() {
         if (!this.props.userId) {
             return {
@@ -102,7 +94,7 @@ class TripRequestsTable extends Component {
                 columnNames={this.prepareTableHeaders()}
                 items={this.prepareTableContent(trips)}
                 itemKey="id"
-                linkKey={this.linkKey()}
+                linkKey={this.props.userId ? 'id' : 'userId'}
                 link={this.linkElement()}
             />
         );

--- a/src/commons/table/index.jsx
+++ b/src/commons/table/index.jsx
@@ -24,7 +24,8 @@ import './table.scss';
 *
 * link: is an object describing the links to be created on the table, it needs a
 * prefix and a columnName name, to create a link with the prefix url  followed by the
-* itemKey value for the object.
+* itemKey value for the object. A suffix can also be specified, appending a given string
+* in the end of the link, this is optional.
 *
 * search (optional): Boolean. Add as a parameter if you want the table to be searchable
 *
@@ -133,11 +134,15 @@ class Table extends Component {
     }
 
     renderCell(item, columnNameKey, itemKey, link) {
+        const suffix = link.suffix || '';
         let element = (<td>{item[columnNameKey]}</td>);
         if (link && link.columnName === columnNameKey) {
             element = (
                 <td>
-                    <Link to={link.prefix + item[this.getLinkId()]} activeClassName="item-active">
+                    <Link
+                        to={link.prefix + item[this.getLinkId()] + suffix}
+                        activeClassName="item-active"
+                    >
                         {item[columnNameKey]}
                     </Link>
                 </td>

--- a/src/commons/trip/tripInfo.jsx
+++ b/src/commons/trip/tripInfo.jsx
@@ -1,9 +1,9 @@
 import React, { PropTypes } from 'react';
 
-import { TRAVEL_METHODS } from '../../../constants';
-import List from '../../../commons/list';
-import ListItem from '../../../commons/list/listItem';
-import FluidListItem from '../../../commons/list/fluidListItem';
+import { TRAVEL_METHODS } from '../../constants';
+import List from '../list';
+import ListItem from '../list/listItem';
+import FluidListItem from '../list/fluidListItem';
 import moment from 'moment';
 
 const MOMENT_FORMAT = 'YYYY-MM-DD';

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -25,6 +25,7 @@ import SignupTrip from './sections/trips/signup';
 import Trips from './sections/trips/';
 import Trip from './sections/trips/trip';
 import TripRequests from './sections/admin/trips';
+import AdminTrip from './sections/admin/trips/trip';
 import EditTrip from './sections/trips/trip/editTrip';
 import TripInfo from './sections/trips/trip/tripInfo';
 import Email from './sections/admin/email';
@@ -85,7 +86,10 @@ export default(
                     </Route>
                 </Route>
                 <Route name="Email" path="admin/email/:emailId" component={Email} />
-                <Route name="Trips" path="admin/trips" component={TripRequests} />
+                <Route name="Trips" path="admin/trips">
+                    <IndexRoute component="TripRequests" />
+                    <Route path=":tripId" component={AdminTrip} />
+                </Route>
                 <Route name="Not found" path="*" component={NotFound} />
             </Route>
         </Route>

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -87,7 +87,7 @@ export default(
                 </Route>
                 <Route name="Email" path="admin/email/:emailId" component={Email} />
                 <Route name="Trips" path="admin/trips">
-                    <IndexRoute component="TripRequests" />
+                    <IndexRoute component={TripRequests} />
                     <Route path=":tripId" component={AdminTrip} />
                 </Route>
                 <Route name="Not found" path="*" component={NotFound} />

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -27,7 +27,7 @@ import Trip from './sections/trips/trip';
 import TripRequests from './sections/admin/trips';
 import AdminTrip from './sections/admin/trips/trip';
 import EditTrip from './sections/trips/trip/editTrip';
-import TripInfo from './sections/trips/trip/tripInfo';
+import TripInfo from './commons/trip/tripInfo';
 import Email from './sections/admin/email';
 import Users from './sections/admin/users';
 import User from './sections/admin/users/user';
@@ -88,7 +88,9 @@ export default(
                 <Route name="Email" path="admin/email/:emailId" component={Email} />
                 <Route name="Trips" path="admin/trips">
                     <IndexRoute component={TripRequests} />
-                    <Route path=":tripId" component={AdminTrip} />
+                    <Route path=":tripId" component={AdminTrip}>
+                        <IndexRoute component={TripInfo} />
+                    </Route>
                 </Route>
                 <Route name="Not found" path="*" component={NotFound} />
             </Route>

--- a/src/sections/admin/trips/trip/index.jsx
+++ b/src/sections/admin/trips/trip/index.jsx
@@ -3,8 +3,23 @@ import { connect } from 'react-redux';
 
 import Header from '../../../../commons/pageHeader';
 import { retrieve } from '../../../../actions/tripActions';
+import { retrieve as retrieveDestination } from '../../../../actions/destinationActions';
+import { retrieve as retrieveUser } from '../../../../actions/userActions';
 
-const createHandlers = (dispatch) => (id) => dispatch(retrieve(id));
+
+const createHandlers = (dispatch) => (
+    {
+        retrieve(id) {
+            return dispatch(retrieve(id));
+        },
+        retrieveDestination(id) {
+            return dispatch(retrieveDestination(id));
+        },
+        retrieveUser(id) {
+            return dispatch(retrieveUser(id));
+        }
+    }
+);
 
 class Trip extends Component {
     constructor(props) {
@@ -13,17 +28,22 @@ class Trip extends Component {
     }
 
     componentDidMount() {
-        this.handlers(this.props.params.tripId);
+        this.handlers.retrieve(this.props.params.tripId)
+        .then(() => {
+            this.handlers.retrieveDestination(this.props.trip.destinationId);
+            this.handlers.retrieveUser(this.props.trip.userId);
+        });
     }
 
     render() {
-        console.log(this.props.trip);
+        const headerTitle = `Trip to ${this.props.destination.name}`;
+
         return (
             <div className="ui segments">
                 <div className="ui segment">
                     <Header
                         icon="plane"
-                        content="Trip to [Destination name]"
+                        content={headerTitle}
                         subContent="Manage trip"
                     />
                 </div>
@@ -35,13 +55,17 @@ class Trip extends Component {
 }
 
 const mapStateToProps = store => ({
-    trip: store.tripState.trip
+    destination: store.destinationState.destination,
+    trip: store.tripState.trip,
+    user: store.userState.user
 });
 
 Trip.propTypes = {
+    destination: PropTypes.object.isRequired,
     dispatch: PropTypes.func.isRequired,
     params: PropTypes.object.isRequired,
-    trip: PropTypes.object.isRequired
+    trip: PropTypes.object.isRequired,
+    user: PropTypes.object.isRequired
 };
 
 export default connect(mapStateToProps)(Trip);

--- a/src/sections/admin/trips/trip/index.jsx
+++ b/src/sections/admin/trips/trip/index.jsx
@@ -1,7 +1,12 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
+import moment from 'moment';
+
 
 import Header from '../../../../commons/pageHeader';
+import List from '../../../../commons/list';
+import ListItem from '../../../../commons/list/listItem';
+import FluidListItem from '../../../../commons/list/fluidListItem';
 import { retrieve } from '../../../../actions/tripActions';
 import { retrieve as retrieveDestination } from '../../../../actions/destinationActions';
 import { retrieve as retrieveUser } from '../../../../actions/userActions';
@@ -48,6 +53,38 @@ class Trip extends Component {
                     />
                 </div>
                 <div className="ui segment">
+                    <List>
+                        <ListItem
+                            name="First name"
+                            icon="user"
+                            content={this.props.user.firstname}
+                        />
+                        <ListItem
+                            name="Last name"
+                            icon="user"
+                            content={this.props.user.lastname}
+                        />
+                        <ListItem
+                            name="E-mail"
+                            icon="at"
+                            content={this.props.user.email}
+                        />
+                        <ListItem
+                            name="Age"
+                            icon="birthday"
+                            content={moment(this.props.user.birth).fromNow(true)}
+                        />
+                        <ListItem
+                            name="Birthday"
+                            icon="birthday"
+                            content={moment(this.props.user.birth).calendar()}
+                        />
+                        <FluidListItem
+                            name="Occupation and experience"
+                            icon="student"
+                            content={this.props.user.volunteerInfo}
+                        />
+                    </List>
                 </div>
             </div>
         );

--- a/src/sections/admin/trips/trip/index.jsx
+++ b/src/sections/admin/trips/trip/index.jsx
@@ -51,40 +51,11 @@ class Trip extends Component {
                         content={headerTitle}
                         subContent="Manage trip"
                     />
-                </div>
-                <div className="ui segment">
-                    <List>
-                        <ListItem
-                            name="First name"
-                            icon="user"
-                            content={this.props.user.firstname}
-                        />
-                        <ListItem
-                            name="Last name"
-                            icon="user"
-                            content={this.props.user.lastname}
-                        />
-                        <ListItem
-                            name="E-mail"
-                            icon="at"
-                            content={this.props.user.email}
-                        />
-                        <ListItem
-                            name="Age"
-                            icon="birthday"
-                            content={moment(this.props.user.birth).fromNow(true)}
-                        />
-                        <ListItem
-                            name="Birthday"
-                            icon="birthday"
-                            content={moment(this.props.user.birth).calendar()}
-                        />
-                        <FluidListItem
-                            name="Occupation and experience"
-                            icon="student"
-                            content={this.props.user.volunteerInfo}
-                        />
-                    </List>
+                    {React.cloneElement(this.props.children, {
+                        initialValues: this.props.trip,
+                        trip: this.props.trip,
+                        onSubmit: e => this.onUpdate(e)
+                    })}
                 </div>
             </div>
         );
@@ -98,6 +69,7 @@ const mapStateToProps = store => ({
 });
 
 Trip.propTypes = {
+    children: PropTypes.object.isRequired,
     destination: PropTypes.object.isRequired,
     dispatch: PropTypes.func.isRequired,
     params: PropTypes.object.isRequired,

--- a/src/sections/admin/trips/trip/index.jsx
+++ b/src/sections/admin/trips/trip/index.jsx
@@ -1,0 +1,47 @@
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+import Header from '../../../../commons/pageHeader';
+import { retrieve } from '../../../../actions/tripActions';
+
+const createHandlers = (dispatch) => (id) => dispatch(retrieve(id));
+
+class Trip extends Component {
+    constructor(props) {
+        super(props);
+        this.handlers = createHandlers(this.props.dispatch);
+    }
+
+    componentDidMount() {
+        this.handlers(this.props.params.tripId);
+    }
+
+    render() {
+        console.log(this.props.trip);
+        return (
+            <div className="ui segments">
+                <div className="ui segment">
+                    <Header
+                        icon="plane"
+                        content="Trip to [Destination name]"
+                        subContent="Manage trip"
+                    />
+                </div>
+                <div className="ui segment">
+                </div>
+            </div>
+        );
+    }
+}
+
+const mapStateToProps = store => ({
+    trip: store.tripState.trip
+});
+
+Trip.propTypes = {
+    dispatch: PropTypes.func.isRequired,
+    params: PropTypes.object.isRequired,
+    trip: PropTypes.object.isRequired
+};
+
+export default connect(mapStateToProps)(Trip);


### PR DESCRIPTION
# Pull request at a glance
- Add single trip view for administrators.
- Update the common table component to allow for a suffix parameter.
- Link from the trip requests page points directly to an overview of a user's trips.
- Link from user trip overview points to a single trip.

![screenshot from 2016-08-04 15-03-30](https://cloud.githubusercontent.com/assets/5208030/17402671/af1d2a2c-5a54-11e6-9503-d563b3172c1c.png)
![screenshot from 2016-08-05 12-55-48](https://cloud.githubusercontent.com/assets/5208030/17434662/fb7d7e50-5b0b-11e6-9477-4340386dd7c7.png)
![screenshot from 2016-08-05 12-55-52](https://cloud.githubusercontent.com/assets/5208030/17434663/fb82475a-5b0b-11e6-8107-040bf7815da0.png)

[See DIH-281](https://jira.capraconsulting.no/browse/DIH-281)
