### PR TITLE
Add cancel trip form to user view

### DIFF
--- a/src/middleware/api.js
+++ b/src/middleware/api.js
@@ -18,7 +18,9 @@ export default store => next => action => { // eslint-disable-line
     API.interceptors.response.use(response => (
         Promise.resolve(response)
     ), error => {
-        if (error.status === 401) store.dispatch(logout());
+        if (error.status >= 400 && error.status < 500) {
+            store.dispatch(logout()); // Errors lead to logout
+        }
         return Promise.reject(error);
     });
 

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -26,6 +26,7 @@ import Trips from './sections/trips/';
 import Trip from './sections/trips/trip';
 import TripRequests from './sections/admin/trips';
 import EditTrip from './sections/trips/trip/editTrip';
+import CancelTrip from './sections/trips/trip/cancelTrip';
 import TripInfo from './sections/trips/trip/tripInfo';
 import Email from './sections/admin/email';
 import Users from './sections/admin/users';
@@ -57,7 +58,8 @@ export default(
                     <Route name="Sign up" path="signup" component={SignupTrip} />
                     <Route path=":tripId" component={Trip}>
                         <IndexRoute component={TripInfo} />
-                        <Route name="edit" path="edit" component={EditTrip} />
+                        <Route name="Edit" path="edit" component={EditTrip} />
+                        <Route name="Cancel" path="cancel" component={CancelTrip} />
                     </Route>
                 </Route>
                 <Route name="Destinations" path="admin/destinations">

--- a/src/sections/trips/trip/cancelTrip.jsx
+++ b/src/sections/trips/trip/cancelTrip.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { reduxForm } from 'redux-form';
+import { Link } from 'react-router';
+
+import Button from '../../../commons/Button';
+
+// This form is not using the Form-component so it does not conflict with the methods of editTrip
+function CancelTrip(props) {
+    const {
+        isFetching
+    } = props;
+
+    return (
+        <div>
+            <h3>Do you really want to cancel your trip to {props.destination.name}?</h3>
+            <p>
+                You can cancel your trip at any time - we don't ask questions.
+                If you at a later time want to go on a
+                trip again, just go to the <Link to="/trips/signup">
+                    trip sign-up page
+                </Link>.
+            </p>
+            <p>
+                If you're unsure about your trip, or have any questions at all,
+                please contact us so we can help you.
+                You can contact us <a target="_blank" rel="noopener noreferrer" href="http://www.drapenihavet.no/en/contact/">here</a>.
+            </p>
+            <form
+                id="cancelTripForm"
+                onSubmit={e => {
+                    e.preventDefault();
+                    props.onCancel(e);
+                }}
+            >
+                <Button
+                    type="submit"
+                    color="red"
+                    fluid
+                    loading={isFetching}
+                    id="submit"
+                >
+                    Confirm cancelation of trip
+                </Button>
+            </form>
+        </div>
+    );
+}
+
+CancelTrip.propTypes = {
+    trip: React.PropTypes.object.isRequired,
+    destination: React.PropTypes.object.isRequired,
+    onCancel: React.PropTypes.func.isRequired,
+    errorMessage: React.PropTypes.string,
+    isFetching: React.PropTypes.bool
+};
+
+export default reduxForm({
+    form: 'cancelTripForm',
+    fields: []
+})(CancelTrip);

--- a/src/sections/trips/trip/editTrip.jsx
+++ b/src/sections/trips/trip/editTrip.jsx
@@ -149,7 +149,7 @@ function EditTrip(props) {
                 <Button
                     type="submit"
                     color="green"
-                    right
+                    fluid
                     loading={isFetching}
                     id="submit"
                 >

--- a/src/sections/trips/trip/index.jsx
+++ b/src/sections/trips/trip/index.jsx
@@ -7,6 +7,7 @@ import Navbar from '../../../commons/navbar';
 import { retrieve, update } from '../../../actions/tripActions';
 import { retrieve as retrieveDestination } from '../../../actions/destinationActions';
 import { pushNotification } from '../../../actions/notificationActions';
+import { TRIP_STATUSES } from '../../../constants';
 
 const createHandlers = (dispatch) => (
     {
@@ -55,6 +56,10 @@ class Trip extends React.Component {
                 {
                     name: 'Edit',
                     uri: `/trips/${this.props.params.tripId}/edit`
+                },
+                {
+                    name: 'Cancel',
+                    uri: `/trips/${this.props.params.tripId}/cancel`
                 }
             ]
         };
@@ -78,6 +83,17 @@ class Trip extends React.Component {
         .then(() => browserHistory.push(`/trips/${this.props.params.tripId}`));
     }
 
+    onCancel() {
+        this.handlers.update({ status: TRIP_STATUSES.CLOSED, id: this.props.params.tripId })
+        .then(response => {
+            const message = 'Trip is canceled.';
+            const { error } = response;
+            if (!error) this.handlers.notification(message, 'success');
+            if (error) this.handlers.notification('There was a problem. Try again later.', 'error');
+            browserHistory.push('/trips');
+        });
+    }
+
     render() {
         return (
             <div className="ui segment clearing">
@@ -90,7 +106,9 @@ class Trip extends React.Component {
                 {React.cloneElement(this.props.children, {
                     initialValues: this.props.trip,
                     trip: this.props.trip,
-                    onSubmit: e => this.onUpdate(e)
+                    destination: this.props.destination,
+                    onSubmit: e => this.onUpdate(e),
+                    onCancel: e => this.onCancel(e)
                 })}
             </div>
         );


### PR DESCRIPTION
## At a glance
- Add form to trip-view of user for canceling the trip. It does not use Form-component as it kills the edit-form
- Automatically log user out if it gets any `400`-error from backend
- Make the save-button for trip edit-form fluid so that users can see it better
## Screenshot

![image](https://cloud.githubusercontent.com/assets/1620267/17410719/35638b24-5a75-11e6-9bfa-ae24bba315b9.png)
## References

See [DIH-278](https://jira.capraconsulting.no/browse/DIH-278)
