### PR TITLE
Split admin trips into two components

### DIFF
--- a/src/commons/adminTripTable/index.jsx
+++ b/src/commons/adminTripTable/index.jsx
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import TripRequestsTable from './tripRequestsTable';
+import TripsTable from './tripsTable';
 import { list } from '../../actions/tripActions';
 
 /*
@@ -29,10 +29,11 @@ class AdminTripTable extends Component {
 
     render() {
         return (
-            <TripRequestsTable
+            <TripsTable
                 trips={this.props.trips}
                 userId={this.props.userId}
                 destinationId={this.props.destinationId}
+                requestsOnly={this.props.requestsOnly}
             />
         );
     }
@@ -46,7 +47,8 @@ AdminTripTable.propTypes = {
     trips: PropTypes.array.isRequired,
     userId: PropTypes.number,
     destinationId: PropTypes.number,
-    dispatch: PropTypes.func.isRequired
+    dispatch: PropTypes.func.isRequired,
+    requestsOnly: PropTypes.bool
 };
 
 export default connect(mapStateToProps)(AdminTripTable);

--- a/src/commons/adminTripTable/tripsTable.jsx
+++ b/src/commons/adminTripTable/tripsTable.jsx
@@ -3,6 +3,7 @@ import moment from 'moment';
 
 import Table from '../../commons/table';
 import TripStatusDropdown from './tripStatusDropdown';
+import { TRIP_STATUSES } from '../../constants';
 
 class TripRequestsTable extends Component {
     getTrips() {
@@ -42,7 +43,12 @@ class TripRequestsTable extends Component {
     }
 
     prepareTableContent(trips) {
-        return trips.map(trip => {
+        let filteredTrips = trips;
+        if (this.props.requestsOnly) {
+            filteredTrips = trips.filter(trip => (trip.status === TRIP_STATUSES.PENDING));
+        }
+
+        return filteredTrips.map(trip => {
             const row = {
                 id: trip.id,
                 userId: trip.uiserId,
@@ -89,7 +95,8 @@ class TripRequestsTable extends Component {
 TripRequestsTable.propTypes = {
     trips: PropTypes.array.isRequired,
     userId: PropTypes.number,
-    destinationId: PropTypes.number
+    destinationId: PropTypes.number,
+    requestsOnly: PropTypes.bool
 };
 
 export default TripRequestsTable;

--- a/src/commons/sidebar/index.jsx
+++ b/src/commons/sidebar/index.jsx
@@ -60,7 +60,7 @@ class Sidebar extends Component {
             {this.props.account.role === 'ADMIN' && <SidebarMenuGroup groupName="Admin" icon="user">
                 <SidebarMenuItem uri="/admin/users" itemName="Users" />
                 <SidebarMenuItem uri="/admin/destinations" itemName="Destinations" />
-                <SidebarMenuItem uri="/admin/trips" itemName="Trip Requests" />
+                <SidebarMenuItem uri="/admin/trips" itemName="Trips" />
             </SidebarMenuGroup>}
             <Account account={this.props.account} onLogout={e => { this.handleLogout(e); }} />
         </div>);

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -24,7 +24,9 @@ import AddDestination from './sections/admin/destinations/addDestination';
 import SignupTrip from './sections/trips/signup';
 import Trips from './sections/trips/';
 import Trip from './sections/trips/trip';
-import TripRequests from './sections/admin/trips';
+import AdminTrips from './sections/admin/trips';
+import AdminTripsAll from './sections/admin/trips/allTrips';
+import AdminTripsRequests from './sections/admin/trips/tripRequests';
 import EditTrip from './sections/trips/trip/editTrip';
 import TripInfo from './sections/trips/trip/tripInfo';
 import Email from './sections/admin/email';
@@ -85,7 +87,10 @@ export default(
                     </Route>
                 </Route>
                 <Route name="Email" path="admin/email/:emailId" component={Email} />
-                <Route name="Trips" path="admin/trips" component={TripRequests} />
+                <Route name="Trips" path="admin/trips" component={AdminTrips}>
+                    <IndexRoute component={AdminTripsAll} />
+                    <Route name="Trip requests" path="requests" component={AdminTripsRequests} />
+                </Route>
                 <Route name="Not found" path="*" component={NotFound} />
             </Route>
         </Route>

--- a/src/sections/admin/trips/allTrips.jsx
+++ b/src/sections/admin/trips/allTrips.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import AdminTripTable from '../../../commons/adminTripTable';
+
+function AllTrips() {
+    return (
+        <AdminTripTable />
+    );
+}
+
+export default AllTrips;

--- a/src/sections/admin/trips/index.jsx
+++ b/src/sections/admin/trips/index.jsx
@@ -1,21 +1,38 @@
-import React from 'react';
+import React, { Component } from 'react';
 
 import Header from '../../../commons/pageHeader';
-import AdminTripTable from '../../../commons/adminTripTable';
+import Navbar from '../../../commons/navbar';
 
-const Trips = () => (
-    <div className="ui segments">
-        <div className="ui segment">
-            <Header
-                icon="plane"
-                content="Trip requests"
-                subContent="Review trip requests from volunteers"
-            />
-        </div>
-        <div className="ui segment">
-            <AdminTripTable />
-        </div>
-    </div>
-);
+class Trips extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            pages: [
+                {
+                    name: 'All trips',
+                    uri: '/admin/trips'
+                },
+                {
+                    name: 'Requests',
+                    uri: '/admin/trips/requests'
+                }
+            ]
+        };
+    }
+
+    render() {
+        return (
+            <div className="ui segment">
+                <Header
+                    icon="plane"
+                    content="Trips"
+                    subContent="Manage and review trips from volunteers"
+                />
+                <Navbar pages={this.state.pages} />
+                {this.props.children}
+            </div>
+        );
+    }
+}
 
 export default Trips;

--- a/src/sections/admin/trips/tripRequests.jsx
+++ b/src/sections/admin/trips/tripRequests.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import AdminTripTable from '../../../commons/adminTripTable';
+
+function TripRequests() {
+    return (
+        <AdminTripTable requestsOnly />
+    );
+}
+
+export default TripRequests;


### PR DESCRIPTION
## The pull request at a glance
- Split trip administration into all trips and requests only

![screenshot from 2016-08-04 20-14-32](https://cloud.githubusercontent.com/assets/5208030/17413173/6bc89c76-5a80-11e6-8167-cc89ed4879e9.png)
![screenshot from 2016-08-04 20-14-34](https://cloud.githubusercontent.com/assets/5208030/17413172/6bc775da-5a80-11e6-8f12-7e9bf46217f7.png)

See [DIH-257](https://jira.capraconsulting.no/browse/DIH-257)
