### PR TITLE
[Doppins] Upgrade dependency babel-core to ~6.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "autoprefixer": "~6.4.0",
     "babel-cli": "~6.10.1",
-    "babel-core": "~6.13.0",
+    "babel-core": "~6.13.1",
     "babel-loader": "~6.2.4",
     "babel-plugin-transform-object-rest-spread": "~6.8.0",
     "babel-preset-es2015": "~6.9.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "autoprefixer": "~6.4.0",
     "babel-cli": "~6.10.1",
-    "babel-core": "~6.10.4",
+    "babel-core": "~6.13.0",
     "babel-loader": "~6.2.4",
     "babel-plugin-transform-object-rest-spread": "~6.8.0",
     "babel-preset-es2015": "~6.9.0",


### PR DESCRIPTION
Hi!

A new version was just released of `babel-core`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded babel-core from `~6.10.4` to `~6.13.0`
#### Changelog:
#### Version 6.11.4
## v6.11.4 (2016-07-20)

> Please [join](http://slack.babeljs.io) [#discussion](https://babeljs.slack.com/messages/discussion) on slack if you have questions and [#development](https://babeljs.slack.com/messages/development) for dev
> 
> FYI: Babel releases don't mean each package updates. If a package isn't changed it keeps it's version number. The changelog entries below tell you what specific packages have changed. You shouldn't have to do anything in most cases other than `npm install` again.

In this release (among other things) are some more optimizations for babel-generator (`#3584`](`https://github.com/babel/babel/pull/3584`), [`#3580` (`https://github.com/babel/babel/pull/3580`)) as well as refactors.

[`@jamestalmage`](https://github.com/jamestalmage) did some awesome clean for OptionsManager and some tests which may help future improvements to `babel-register` performance.
#### Bug Fix
- `babel-plugin-transform-remove-console`, `babel-plugin-transform-remove-debugger`, `babel-traverse`
  - `#3583` (`https://github.com/babel/babel/pull/3583`) Add block if parent is non-block statement for remove-console/debugger. ([`@jhen0409`](https://github.com/jhen0409))
- `babel-plugin-transform-regenerator`
  - `#3586`](`https://github.com/babel/babel/pull/3586`) Avoid duplicated identifier sharing location - Fixes [`#7436` (`https://github.com/babel/babel/issues/7436`). ([`@loganfsmyth`](https://github.com/loganfsmyth))
- `babel-cli`
  - `#3578` (`https://github.com/babel/babel/pull/3578`) Support all variations of v8Flags in babel-node. ([`@danez`](https://github.com/danez))
#### Polish
- `babel-core`
  - `#3564` (`https://github.com/babel/babel/pull/3564`) Extract config file resolution from OptionsManager . ([`@jamestalmage`](https://github.com/jamestalmage))
- `babel-generator`, `babel-plugin-transform-es2015-modules-commonjs`
  - `#3584` (`https://github.com/babel/babel/pull/3584`) babel-generator: More refactoring and optimizations. ([`@loganfsmyth`](https://github.com/loganfsmyth))
- `babel-plugin-transform-es2015-parameters`
  - `#3574` (`https://github.com/babel/babel/pull/3574`) Default parameters cleanup. ([`@jridgewell`](https://github.com/jridgewell))
- `babel-generator`
  - `#3581` (`https://github.com/babel/babel/pull/3581`) babel-generator: Misc cleanup and stale code removal. ([`@loganfsmyth`](https://github.com/loganfsmyth))
  - `#3580` (`https://github.com/babel/babel/pull/3580`) Further optimize babel-generator Buffer. ([`@jridgewell`](https://github.com/jridgewell))
#### Commiters: 6
- Daniel Tschinder ([danez](https://github.com/danez))
- Henry Zhu ([hzoo](https://github.com/hzoo))
- James Talmage ([jamestalmage](https://github.com/jamestalmage))
- Jhen-Jie Hong ([jhen0409](https://github.com/jhen0409))
- Justin Ridgewell ([jridgewell](https://github.com/jridgewell))
- Logan Smyth ([loganfsmyth](https://github.com/loganfsmyth))
