### PR TITLE
[Doppins] Upgrade dependency babel-preset-es2015 to ~6.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "babel-core": "~6.10.4",
     "babel-loader": "~6.2.4",
     "babel-plugin-transform-object-rest-spread": "~6.8.0",
-    "babel-preset-es2015": "~6.9.0",
+    "babel-preset-es2015": "~6.13.0",
     "babel-preset-react": "~6.11.1",
     "babel-preset-stage-0": "~6.5.0",
     "bluebird": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "babel-core": "~6.10.4",
     "babel-loader": "~6.2.4",
     "babel-plugin-transform-object-rest-spread": "~6.8.0",
-    "babel-preset-es2015": "~6.13.0",
+    "babel-preset-es2015": "~6.13.1",
     "babel-preset-react": "~6.11.1",
     "babel-preset-stage-0": "~6.5.0",
     "bluebird": "^3.4.1",


### PR DESCRIPTION
Hi!

A new version was just released of `babel-preset-es2015`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded babel-preset-es2015 from `~6.9.0` to `~6.13.0`
