### PR TITLE
Add noshow status

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -26,6 +26,7 @@ export const USER_ROLES = {
  * @property {string} CLOSED - The trip is closed, hence the user has completed this trip
  * @property {string} PRESENT - User is present at destination
  * @property {string} LEFT - User has left destination
+ * @property {string} NOSHOW - User did not show up at destination
  */
 export const TRIP_STATUSES = {
     PENDING: 'PENDING',
@@ -34,7 +35,8 @@ export const TRIP_STATUSES = {
     ACTIVE: 'ACTIVE',
     CLOSED: 'CLOSED',
     PRESENT: 'PRESENT',
-    LEFT: 'LEFT'
+    LEFT: 'LEFT',
+    NOSHOW: 'NO SHOW'
 };
 
 /**

--- a/src/sections/trips/signup/index.jsx
+++ b/src/sections/trips/signup/index.jsx
@@ -1,10 +1,12 @@
 import React, { PropTypes, Component } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
+import moment from 'moment';
 import SignupTripForm from './SignupTripForm';
 import Header from '../../../commons/pageHeader';
 import { create } from '../../../actions/tripActions';
 import { list } from '../../../actions/destinationActions';
+import { pushNotification } from '../../../actions/notificationActions';
 
 const createHandlers = dispatch => ({
     create(data) {
@@ -12,6 +14,9 @@ const createHandlers = dispatch => ({
     },
     list() {
         return dispatch(list());
+    },
+    notification(message, level) {
+        return dispatch(pushNotification(message, level));
     }
 });
 
@@ -41,20 +46,37 @@ class SignupTripFormContainer extends Component {
         });
         const trip = data;
         trip.wishStartDate = data.startDate; // Cannot be null. Field is not used anymore.
-        this.handlers.create(trip)
-            .then(response => {
-                let success = null;
-                const { error } = response;
-                if (!error) {
-                    success = `We have registered your trip request and
-                    will respond by email as soon as possible.`;
-                }
+        if (trip.endDate) {
+            const timeDiff = moment(trip.endDate).diff(moment(trip.startDate), 'days');
+            const destId = parseInt(trip.destinationId, 10);
+            const destination = this.props.destinations.filter(e => e.id === destId)[0];
+            if (destination && timeDiff < destination.minimumTripDurationInDays) {
+                const msg = `Trip duration has to be longer
+                than ${destination.minimumTripDurationInDays} days for this destination.
+                If you're unsure of the length of your stay, don't set any end date, and
+                explain your situation in the "Additional information" field at the bottom.`;
                 this.setState({
-                    errorMessage: error,
                     isFetching: false,
-                    successMessage: success
+                    errorMessage: msg,
+                    successMessage: null
                 });
+                return;
+            }
+        }
+        this.handlers.create(trip)
+        .then(response => {
+            let success = null;
+            const { error } = response;
+            if (!error) {
+                success = `We have registered your trip request and
+                will respond by email as soon as possible.`;
+            }
+            this.setState({
+                errorMessage: error,
+                isFetching: false,
+                successMessage: success
             });
+        });
     }
 
     renderSignUpForTripForm() {

--- a/src/sections/trips/trip/tripInfo.jsx
+++ b/src/sections/trips/trip/tripInfo.jsx
@@ -11,6 +11,11 @@ const MOMENT_FORMAT = 'YYYY-MM-DD';
 const TripInfo = (props) => (
     <List>
         <ListItem
+            name="Status"
+            icon="circle"
+            content={props.trip.status}
+        />
+        <ListItem
             name="Start date"
             icon="calendar"
             content={props.trip.startDate ?


### PR DESCRIPTION
## At a glance
- Adds trip status `NO SHOW` to `constants`
- Validate trip length before signup (_not a part of this task, see references_)
- Show trip status in view of single trip
## Screenshots

![image](https://cloud.githubusercontent.com/assets/1620267/17433923/b0347a60-5b07-11e6-9038-ef92cd5b2bb5.png)
## References
- See [DIH-270](https://jira.capraconsulting.no/browse/DIH-270)
- [PR for DIH-270 for the API](https://github.com/capraconsulting/dih-api/pull/69)
- Validation is from [DIH-264](https://jira.capraconsulting.no/browse/DIH-264)
