### PR TITLE
Reject endDate before startDate

### DIFF
--- a/src/sections/trips/signup/SignupTripForm.jsx
+++ b/src/sections/trips/signup/SignupTripForm.jsx
@@ -12,6 +12,9 @@ const fields = ['destinationId', 'notes', 'startDate', 'endDate'];
 const validate = values => { // eslint-disable-line
     const errors = {};
     if (!values.startDate) errors.startDate = 'Required';
+    if (values.endDate && values.startDate > values.endDate) {
+        errors.endDate = 'Must be a date after the start date';
+    }
     return errors;
 };
 

--- a/src/sections/trips/signup/SignupTripForm.jsx
+++ b/src/sections/trips/signup/SignupTripForm.jsx
@@ -49,7 +49,7 @@ function SignupTripForm(props) {
             </DateField>
             <DateField
                 label="Date you wish to end your trip (optional)"
-                minDate={moment()}
+                minDate={moment(startDate.value) || moment()}
             >
                 {endDate}
             </DateField>


### PR DESCRIPTION
# At a glance
- Force the user to pick a endDate after startDate
- Add frontend validation if the user bypasses the datepicker

![screenshot from 2016-08-05 13-51-06](https://cloud.githubusercontent.com/assets/5208030/17436074/37c3733e-5b15-11e6-97ca-de472568d56a.png)
![screenshot from 2016-08-05 13-57-38](https://cloud.githubusercontent.com/assets/5208030/17436073/37c0a2f8-5b15-11e6-89a8-c1a8e562d3c5.png)

See [DIH-289](https://jira.capraconsulting.no/browse/DIH-289)
