### PR TITLE
Change dateInterval to be more inclusive

### DIFF
--- a/src/commons/table/index.jsx
+++ b/src/commons/table/index.jsx
@@ -59,18 +59,35 @@ class Table extends Component {
     }
 
     filterDate(array) {
-        const { fromDate, toDate } = this.state;
+        const filterStart = this.state.fromDate;
+        const filterEnd = this.state.toDate;
 
         return array.filter(row => {
-            const rowStartDate = moment(row[this.props.dateFields.from]);
-            const rowEndDate = moment(row[this.props.dateFields.to]);
+            const rowStart = moment(row[this.props.dateFields.from]);
+            const rowEnd = moment(row[this.props.dateFields.to]);
 
-            if (fromDate && toDate) {
-                return rowStartDate.isSameOrAfter(fromDate)
-                    && rowEndDate.isSameOrBefore(toDate);
+
+            if (filterStart && filterEnd) {
+                return (
+                    (rowStart.isSameOrBefore(filterStart) && rowEnd.isSameOrAfter(filterStart)) ||
+                    (rowStart.isSameOrBefore(filterStart) && !rowEnd.isValid()) ||
+                    (rowStart.isSameOrAfter(filterStart) && rowStart.isSameOrBefore(filterEnd))
+                );
             }
-            if (fromDate && !toDate) return rowStartDate.isSameOrAfter(fromDate);
-            if (!fromDate && toDate) return rowEndDate.isSameOrBefore(toDate);
+            if (filterStart && !filterEnd) {
+                return (
+                    rowStart.isSameOrAfter(filterStart) ||
+                    (rowStart.isBefore(filterStart) && rowEnd.isSameOrAfter(filterStart)) ||
+                    (rowStart.isBefore(filterStart) && !rowEnd.isValid())
+                );
+            }
+            if (!filterStart && filterEnd) {
+                return (
+                    rowEnd.isSameOrBefore(filterEnd) ||
+                    (rowEnd.isAfter(filterEnd) && rowStart.isSameOrBefore(filterEnd)) ||
+                    (!rowEnd.isValid() && rowStart.isSameOrBefore(filterEnd))
+                );
+            }
             return true;
         });
     }


### PR DESCRIPTION
- The `dateInterval` component include all rows that have at least one day within the interval

To exemplify the change, I have included some pictures:
### Test data of all trips made in august
- Cell is **green** === Is within the date interval
- Number of greens cells/column === number of active rows within the interval
  <img width="593" alt="screenshot 2016-08-05 14 51 44" src="https://cloud.githubusercontent.com/assets/3471625/17437205/aac3d818-5b1c-11e6-9394-c9e16bf512da.png">
### One day

![trips-same-date](https://cloud.githubusercontent.com/assets/3471625/17438026/245d7e5a-5b21-11e6-82b6-e74d750272cb.png)
### Interval

![trips-different-dates](https://cloud.githubusercontent.com/assets/3471625/17438025/245d42fa-5b21-11e6-9830-e19dbd4bd732.png)
### Only from

![trips-only-from](https://cloud.githubusercontent.com/assets/3471625/17438027/245e2fe4-5b21-11e6-81d2-7c9fc69556d5.png)
### Only to

![trips-only-to](https://cloud.githubusercontent.com/assets/3471625/17438028/245e7df0-5b21-11e6-8923-8d87d9a3e50f.png)
# How can coordinators use this?
### "Who's here right now?"

Set `FROM` and `TO` to today. Set filter to `present`
### "Who will come tomorrow?"

Set `FROM` and `TO` to tomorrow. Set filter to `active`
### "Who will be here SOME days this week?"

Set `FROM` to today and `TO` to a week from now.
### "Who will be here THE WHOLE week?"

**Not possible :(**
### "Who will leave today?"

Set `FROM` and `TO` to today. Set filter to `present`. Sort by date.
## References

See [DIH-279](https://jira.capraconsulting.no/browse/DIH-279)
