### PR TITLE
Only show [ACTIVE, PRESENT, LEFT and NOSHOW] in coordinator view

### DIFF
--- a/src/commons/adminTripTable/index.jsx
+++ b/src/commons/adminTripTable/index.jsx
@@ -42,7 +42,7 @@ class AdminTripTable extends Component {
                     userId={this.props.userId}
                     destinationId={this.props.destinationId}
                     role={this.props.role}
-                    requestsOnly={this.props.requestsOnly}
+                    statuses={this.props.statuses}
                 />
             </Segment>
         );
@@ -59,7 +59,7 @@ AdminTripTable.propTypes = {
     userId: PropTypes.number,
     destinationId: PropTypes.number,
     role: PropTypes.string,
-    requestsOnly: PropTypes.bool
+    statuses: PropTypes.array
 };
 
 export default connect(mapStateToProps)(AdminTripTable);

--- a/src/commons/adminTripTable/tripsTable.jsx
+++ b/src/commons/adminTripTable/tripsTable.jsx
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import moment from 'moment';
-import { USER_ROLES, TRIP_STATUS_LABELS, TRIP_STATUSES } from '../../constants';
+import _ from 'lodash';
+import { USER_ROLES, TRIP_STATUS_LABELS } from '../../constants';
 import Table from '../../commons/table';
 
 class TripRequestsTable extends Component {
@@ -9,6 +10,7 @@ class TripRequestsTable extends Component {
         this.dateFields = { from: 'startDate', to: 'endDate' };
         this.rowCounterLabels = { prefix: 'Showing', suffix: 'trips' };
     }
+
     getTrips() {
         let trips = this.props.trips;
         if (this.props.userId) {
@@ -54,8 +56,8 @@ class TripRequestsTable extends Component {
 
     prepareTableContent(trips) {
         let filteredTrips = trips;
-        if (this.props.requestsOnly) {
-            filteredTrips = trips.filter(trip => (trip.status === TRIP_STATUSES.PENDING));
+        if (this.props.statuses) {
+            filteredTrips = trips.filter(trip => _.includes(this.props.statuses, trip.status));
         }
 
         return filteredTrips.map(trip => {
@@ -128,7 +130,7 @@ TripRequestsTable.propTypes = {
     userId: PropTypes.number,
     destinationId: PropTypes.number,
     role: PropTypes.string,
-    requestsOnly: PropTypes.bool
+    statuses: PropTypes.array
 };
 
 export default TripRequestsTable;

--- a/src/constants.js
+++ b/src/constants.js
@@ -23,8 +23,8 @@ export const USER_ROLES = {
 * @property {string} PENDING - The trip is requested by a user but not handled by an admin
 * @property {string} ACCEPTED - The trip is accepted by an admin
 * @property {string} REJECTED - The trip is rejected by an admin
-* @property {string} ACTIVE - The trip is currently in progress by a user
-* @property {string} CLOSED - The trip is closed, hence the user has completed this trip
+* @property {string} ACTIVE - The trip information is filled out and user is ready for the trip
+* @property {string} CLOSED - The trip is closed. Happens when user cancels the trip
 * @property {string} PRESENT - User is present at destination
 * @property {string} LEFT - User has left destination
 * @property {string} NOSHOW - User did not show up at destination

--- a/src/sections/admin/trips/tripRequests.jsx
+++ b/src/sections/admin/trips/tripRequests.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import AdminTripTable from '../../../commons/adminTripTable';
+import { TRIP_STATUSES } from '../../../constants';
 
-const TripRequests = () => (<AdminTripTable requestsOnly />);
+const TripRequests = () => (<AdminTripTable statuses={[TRIP_STATUSES.PENDING]} />);
 
 export default TripRequests;

--- a/src/sections/coordinator/destinations/destination/index.jsx
+++ b/src/sections/coordinator/destinations/destination/index.jsx
@@ -1,7 +1,7 @@
 import React, { PropTypes, Component } from 'react';
 import { connect } from 'react-redux';
 
-import { USER_ROLES } from '../../../../constants';
+import { USER_ROLES, TRIP_STATUSES } from '../../../../constants';
 import { retrieve } from '../../../../actions/destinationActions';
 import Header from '../../../../commons/pageHeader';
 import Segments from '../../../../commons/Segments';
@@ -17,6 +17,12 @@ class Destination extends Component {
             loading: true
         };
         this.handlers = createHandlers(this.props.dispatch);
+        this.statuses = [
+            TRIP_STATUSES.ACTIVE,
+            TRIP_STATUSES.PRESENT,
+            TRIP_STATUSES.LEFT,
+            TRIP_STATUSES.NOSHOW
+        ];
     }
 
     componentDidMount() {
@@ -39,6 +45,7 @@ class Destination extends Component {
                 <AdminTripTable
                     destinationId={parseInt(this.props.params.destinationId, 10)}
                     role={USER_ROLES.MODERATOR}
+                    statuses={this.statuses}
                 />
             </Segments>
         );


### PR DESCRIPTION
## Overview

Coordinators shouldn't have to worry about trips that are PENDING, REJECTED and so on. It will just be noise. This PR filters the table so that only ACTIVE, PRESENT, LEFT and NOSHOW trips are shown.
## Screenshot

Uhm. Since we don't have a way to change trip status at the moment, I can't get create taste data that would demonstrate this. I did however refactor the `trip requests` view to use the same filtering, and that seems to work just fine.

<img width="1166" alt="screenshot 2016-08-10 15 42 18" src="https://cloud.githubusercontent.com/assets/3471625/17555758/0c11a27e-5f11-11e6-823a-88aad01cbe5c.png">
## References

See [DIH-339](https://jira.capraconsulting.no/browse/DIH-339)
