### PR TITLE
Remove main from breadcrumbs & fix webpack bundling (icon issue)

### DIFF
--- a/src/commons/header/index.jsx
+++ b/src/commons/header/index.jsx
@@ -9,6 +9,7 @@ const Header = (props) => (
             <i className="content big icon" onClick={(e) => props.toggleSidebar(e)} ></i>}
         <div>
             <Breadcrumbs
+                excludes={['Main']}
                 routes={props.routes}
                 params={props.params}
             />

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -124,6 +124,7 @@ export default(
                         </Route>
                     </Route>
                 </Route>
+
                 <Route name="Users" path="admin/users">
                     <IndexRoute component={Users} />
                     <Route path=":userId" component={User}>
@@ -132,13 +133,16 @@ export default(
                         <Route name="Trips" path="trips" component={TripsForUser} />
                     </Route>
                 </Route>
+
                 <Route name="message" path="admin/message" component={Message}>
                     <Route name="recipients" path="recipients" component={RecipientsMessage} />
                     <Route name="compose" path="compose" component={ComposeMessage} />
                     <Route name="summary" path="summary" component={MessageSummary} />
                     <Route name="send" path="send" component={MessageSend} />
                 </Route>
+
                 <Route name="Email" path="admin/email/:emailId" component={Email} />
+
                 <Route name="Trips" path="admin/trips" component={AdminTrips}>
                     <IndexRoute component={AdminTripsAll} />
                     <Route name="Trip requests" path="requests" component={AdminTripsRequests} />

--- a/webpack/base.config.js
+++ b/webpack/base.config.js
@@ -21,28 +21,8 @@ module.exports = {
                 }
             },
             {
-                test: /\.woff(\?v=\d+\.\d+\.\d+)?$/,
-                loader: 'url?limit=10000&mimetype=application/font-woff'
-            },
-            {
-                test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/,
-                loader: 'url?limit=10000&mimetype=application/font-woff'
-            },
-            {
-                test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
-                loader: 'url?limit=10000&mimetype=application/octet-stream'
-            },
-            {
-                test: /\.jpe?g$|\.gif$|\.png$|\.svg$|\.woff$|\.ttf$|\.wav$|\.mp3$/,
-                loader: 'file?name=[path][name].[ext]&context=/the/root/path'
-            },
-            {
-                test: /\.eot(\?v=\d+\.\d+\.\d+)?$/,
-                loader: 'file'
-            },
-            {
-                test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
-                loader: 'url?limit=10000&mimetype=image/svg+xml'
+                test: /\.(png|woff|woff2|eot|ttf|svg)$/,
+                loader: 'url-loader?limit=100000'
             },
             {
                 test: /\.scss$/,

--- a/webpack/production.config.js
+++ b/webpack/production.config.js
@@ -60,28 +60,8 @@ config.module.loaders = [
         }
     },
     {
-        test: /\.woff(\?v=\d+\.\d+\.\d+)?$/,
-        loader: 'url?limit=10000&mimetype=application/font-woff'
-    },
-    {
-        test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/,
-        loader: 'url?limit=10000&mimetype=application/font-woff'
-    },
-    {
-        test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
-        loader: 'url?limit=10000&mimetype=application/octet-stream'
-    },
-    {
-        test: /\.jpe?g$|\.gif$|\.png$|\.svg$|\.woff$|\.ttf$|\.wav$|\.mp3$/,
-        loader: 'file?name=[path][name].[ext]&context=/the/root/path'
-    },
-    {
-        test: /\.eot(\?v=\d+\.\d+\.\d+)?$/,
-        loader: 'file'
-    },
-    {
-        test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
-        loader: 'url?limit=10000&mimetype=image/svg+xml'
+        test: /\.(png|woff|woff2|eot|ttf|svg)$/,
+        loader: 'url-loader?limit=100000'
     }
 ];
 

--- a/webpack/staging.config.js
+++ b/webpack/staging.config.js
@@ -60,28 +60,8 @@ config.module.loaders = [
         }
     },
     {
-        test: /\.woff(\?v=\d+\.\d+\.\d+)?$/,
-        loader: 'url?limit=10000&mimetype=application/font-woff'
-    },
-    {
-        test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/,
-        loader: 'url?limit=10000&mimetype=application/font-woff'
-    },
-    {
-        test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
-        loader: 'url?limit=10000&mimetype=application/octet-stream'
-    },
-    {
-        test: /\.jpe?g$|\.gif$|\.png$|\.svg$|\.woff$|\.ttf$|\.wav$|\.mp3$/,
-        loader: 'file?name=[path][name].[ext]&context=/the/root/path'
-    },
-    {
-        test: /\.eot(\?v=\d+\.\d+\.\d+)?$/,
-        loader: 'file'
-    },
-    {
-        test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
-        loader: 'url?limit=10000&mimetype=image/svg+xml'
+        test: /\.(png|woff|woff2|eot|ttf|svg)$/,
+        loader: 'url-loader?limit=100000'
     }
 ];
 


### PR DESCRIPTION
This pull request removes `Main` from breadcrumbs and improves webpack bundling

See [DIH-331](https://jira.capraconsulting.no/browse/DIH-331)
See [DIH-293](https://jira.capraconsulting.no/browse/DIH-293)

<img width="1551" alt="skjermbilde 2016-08-11 kl 07 36 45" src="https://cloud.githubusercontent.com/assets/5478280/17579483/649c1bce-5f96-11e6-934f-8fb9404fc8a6.png">
