### PR TITLE
Better birthdays

### DIFF
--- a/src/commons/user/editUser.jsx
+++ b/src/commons/user/editUser.jsx
@@ -4,7 +4,6 @@ import { reduxForm } from 'redux-form';
 import Form from '../Form';
 import Button from '../Button';
 import Segment from '../Segment';
-import DateField from '../Form/DateField';
 import InputField from '../Form/InputField';
 import SelectField from '../Form/SelectField';
 import TextField from '../Form/TextField';
@@ -82,13 +81,13 @@ function EditUser(props) {
                     </SelectField>
                 )}
 
-                <DateField
-                    label="Date of birth"
+                <InputField
+                    label="Date of birth (YYYY-MM-DD)"
                     placeholder="YYYY-MM-DD"
                     required
                 >
                     {birth}
-                </DateField>
+                </InputField>
                 <TextField
                     rows={3}
                     label="Occupation and experience"

--- a/src/commons/user/viewUser.jsx
+++ b/src/commons/user/viewUser.jsx
@@ -29,8 +29,8 @@ const ViewUser = (props) => (
             <ListItem
                 name="Birthday"
                 icon="birthday"
-                content={props.user.birth ? `${moment(props.user.birth).calendar()}
-                (${moment(props.user.birth).fromNow(true)} old)` : 'Not set'}
+                content={props.user.birth ? `${moment(props.user.birth).format('MMMM Do YYYY')}
+                (${moment().diff(moment(props.user.birth), 'years')} years old)` : 'Not set'}
             />
             <ListItem
                 name="E-mail"

--- a/src/sections/admin/trips/trip/index.jsx
+++ b/src/sections/admin/trips/trip/index.jsx
@@ -37,13 +37,14 @@ class Trip extends Component {
                     uri: `/admin/trips/${this.props.params.tripId}`
                 },
                 {
-                    name: 'User',
-                    uri: `/admin/trips/${this.props.params.tripId}/user`
-                },
-                {
                     name: 'Edit',
                     uri: `/admin/trips/${this.props.params.tripId}/edit`
+                },
+                {
+                    name: 'User',
+                    uri: `/admin/trips/${this.props.params.tripId}/user`
                 }
+
             ]
         };
         this.handlers = createHandlers(this.props.dispatch);

--- a/src/sections/admin/users/user/index.jsx
+++ b/src/sections/admin/users/user/index.jsx
@@ -1,10 +1,12 @@
 import React, { PropTypes, Component } from 'react';
 import { connect } from 'react-redux';
 import { browserHistory } from 'react-router';
+import moment from 'moment';
 import { retrieve, update, destroy } from '../../../../actions/userActions';
 import { retrieve as retrieveAccount } from '../../../../actions/accountActions';
 import { pushNotification } from '../../../../actions/notificationActions';
 import Segment from '../../../../commons/Segment';
+import Segments from '../../../../commons/Segments';
 import Header from '../../../../commons/pageHeader';
 import Navbar from '../../../../commons/navbar';
 
@@ -75,24 +77,28 @@ class User extends Component {
             .then(() => browserHistory.push(`/admin/users/${userId}`));
     }
 
+    prepareInitialValues(user) {
+        return { ...user, birth: moment(user.birth).format('YYYY-MM-DD') };
+    }
+
     render() {
         return (
-            <Segment clearing loading={this.state.loading}>
-                <Header
-                    icon="user"
-                    content={`${this.props.user.firstname} ${this.props.user.lastname}`}
-                    subContent="Manage user"
-                />
-                <Navbar pages={this.state.pages} />
-                <Segment clearing>
-                    {React.cloneElement(this.props.children, {
-                        initialValues: this.props.user,
-                        user: this.props.user,
-                        showAdminFields: true,
-                        onSubmit: e => this.onUpdate(e)
-                    })}
+            <Segments loading={this.state.loading}>
+                <Segment>
+                    <Header
+                        icon="user"
+                        content={`${this.props.user.firstname} ${this.props.user.lastname}`}
+                        subContent="Manage user"
+                    />
                 </Segment>
-            </Segment>
+                <Navbar pages={this.state.pages} />
+                {React.cloneElement(this.props.children, {
+                    initialValues: this.prepareInitialValues(this.props.user),
+                    user: this.props.user,
+                    showAdminFields: true,
+                    onSubmit: e => this.onUpdate(e)
+                })}
+            </Segments>
         );
     }
 }

--- a/src/sections/profile/index.jsx
+++ b/src/sections/profile/index.jsx
@@ -1,6 +1,8 @@
 import React, { PropTypes, Component } from 'react';
 import { connect } from 'react-redux';
 import { browserHistory } from 'react-router';
+import moment from 'moment';
+
 import { update, retrieve } from '../../actions/accountActions';
 import { pushNotification } from '../../actions/notificationActions';
 import Header from '../../commons/pageHeader';
@@ -50,6 +52,10 @@ class Profile extends Component {
         .then(() => browserHistory.push('/profile'));
     }
 
+    prepareInitialValues(account) {
+        return { ...account, birth: moment(account.birth).format('YYYY-MM-DD') };
+    }
+
     render() {
         return (
             <Segments>
@@ -62,7 +68,7 @@ class Profile extends Component {
                 </Segment>
                 <Navbar pages={this.state.pages} />
                 {React.cloneElement(this.props.children, {
-                    initialValues: this.props.account,
+                    initialValues: this.prepareInitialValues(this.props.account),
                     user: this.props.account,
                     showAdminFields: false,
                     onSubmit: e => this.onUpdate(e)


### PR DESCRIPTION
## Overview
- Fix an `age` bug. If a user was 25.6 years old, that was rounded up to 26 years.
- Change date format in `view user` to a more readable format.

<img width="575" alt="screenshot 2016-08-11 11 32 44" src="https://cloud.githubusercontent.com/assets/3471625/17584550/5d637bce-5fb7-11e6-8324-2242d46c4cb6.png">
- Replace the **date of birth** `DateField` with an `InputField`
  <img width="404" alt="screenshot 2016-08-11 11 24 50" src="https://cloud.githubusercontent.com/assets/3471625/17584455/e5f0b19c-5fb6-11e6-941d-bb38093432b1.png">
- Fix a styling bug in `admin/users/user` that added extra padding
## References

[DIH-329](https://jira.capraconsulting.no/browse/DIH-329): Date of birth: Fjern dato-dropdown og skriv "(YYYY-MM-DD)" i labelen
[DIH-340](https://jira.capraconsulting.no/browse/DIH-340): My profile: Age is off by a year
[DIH-367](https://jira.capraconsulting.no/browse/DIH-367): User view padding 
