### PR TITLE
Remove '# volunteers' from the 'destinations' view

### DIFF
--- a/src/sections/admin/destinations/destinationsTable.jsx
+++ b/src/sections/admin/destinations/destinationsTable.jsx
@@ -1,6 +1,5 @@
 import React, { PropTypes, Component } from 'react';
 import { connect } from 'react-redux';
-import _ from 'lodash';
 import moment from 'moment';
 import { list } from '../../../actions/destinationActions';
 import Table from '../../../commons/table';
@@ -41,7 +40,6 @@ class DestinationsList extends Component {
             id: value.id,
             name: value.name,
             minimumTripDurationInDays: value.minimumTripDurationInDays,
-            countOfActiveVolunteers: value.countOfActiveVolunteers,
             isActive: value.isActive,
             startDate: value.startDate ?
                 moment(value.startDate).format('YYYY-MM-DD') : 'Not set',
@@ -58,7 +56,6 @@ class DestinationsList extends Component {
                     dateFields={this.dateFields}
                     columnNames={{
                         name: 'Name',
-                        countOfActiveVolunteers: '# Volunteers',
                         isActive: 'Status',
                         startDate: 'Active from',
                         endDate: 'Active to',
@@ -71,7 +68,6 @@ class DestinationsList extends Component {
                     }}
                     responsivePriority={[
                         'name',
-                        'countOfActiveVolunteers',
                         'isActive',
                         'minimumTripDurationInDays',
                         'endDate',


### PR DESCRIPTION
## Overview
- Remove the `# volunteers` column from the `Destinations` table. 

This functionality is removed since we would have to make some changes to make it work as it should, and the functionality is covered using filters and date intervals.
## Screenshot

<img width="1017" alt="screenshot 2016-08-11 11 52 47" src="https://cloud.githubusercontent.com/assets/3471625/17585137/5a1ee9be-5fba-11e6-9b2f-7d24379ed04b.png">
## References

See [DIH-306](https://jira.capraconsulting.no/browse/DIH-306)
