### PR TITLE
Make the 'coordinator' section of the sidebar show up for admins

### DIFF
--- a/src/commons/sidebar/index.jsx
+++ b/src/commons/sidebar/index.jsx
@@ -62,7 +62,8 @@ class Sidebar extends Component {
                 <SidebarMenuItem uri="/trips/signup" itemName="Sign up for a trip" />
             </SidebarMenuGroup>
 
-            {this.props.account.role === USER_ROLES.MODERATOR &&
+            {(this.props.account.role === USER_ROLES.MODERATOR ||
+            this.props.account.role === USER_ROLES.ADMIN) &&
                 <SidebarMenuGroup groupName="Coordinator" icon="comments">
                     <SidebarMenuItem uri="/coordinator/destinations" itemName="My destinations" />
                 </SidebarMenuGroup>


### PR DESCRIPTION
## Overview
- Show the `coordinator` section of the sidebar to admins as well. 

The `coordinator` section will always be visible to the admin. Ideally it would be nice if it only showed up once your actually a coordinator for a location. However, I don't feel it's worth the effort. 
## Screenshot

<img width="1013" alt="screenshot 2016-08-11 18 43 55" src="https://cloud.githubusercontent.com/assets/3471625/17596854/99e074bc-5ff3-11e6-8b65-7b9932f57d02.png">
## References

[DIH-374](https://jira.capraconsulting.no/browse/DIH-374)
