### PR TITLE
Fix a styling bug with notifications that caused errors to have no ba…

### DIFF
--- a/src/commons/NotificationContainer.jsx
+++ b/src/commons/NotificationContainer.jsx
@@ -6,9 +6,9 @@ import { pushNotification } from '../actions/notificationActions';
 
 const colours = {
     success: '97, 184, 50',
-    error: '#cb020c',
-    warning: '#fb8c1b',
-    info: '#2d5c89'
+    error: '203, 2, 12',
+    warning: '251, 140, 27',
+    info: '45, 92, 137'
 };
 
 const createStyle = (isMobile) => {
@@ -70,7 +70,11 @@ const createStyle = (isMobile) => {
         Dismiss: {
             DefaultStyle: {
                 top: '24px',
-                right: '15px'
+                right: '15px',
+                backgroundColor: 'rgba(1,1,1, 0.3)',
+                width: '16px',
+                height: '16px',
+                paddingTop: '1px'
             }
         }
     };
@@ -95,8 +99,14 @@ class NotificationContainer extends Component {
     componentWillReceiveProps(newProps) {
         if (newProps.isMobile === this.state.isMobile) {
             const { message, level } = newProps.notification;
+
+            let notificationIcon = 'info';
+            if (level === 'error') notificationIcon = 'remove';
+            else if (level === 'success') notificationIcon = 'checkmark';
+            else if (level === 'warning') notificationIcon = 'warning';
+
             this.notificationSystem.addNotification({
-                message: `<i class="info icon"></i> ${message}`,
+                message: `<i class="${notificationIcon} icon"></i> ${message}`,
                 level,
                 position: 'tc',
                 autoDismiss: 7


### PR DESCRIPTION
## Overview

There was a bug that caused notification errors to invisible. Like this:
<img width="1114" alt="screenshot 2016-08-11 19 19 23" src="https://cloud.githubusercontent.com/assets/3471625/17597983/9b9ba358-5ff8-11e6-807a-fdb9e2eadc97.png">

This is now fixed: 
<img width="1177" alt="screenshot 2016-08-11 19 02 59" src="https://cloud.githubusercontent.com/assets/3471625/17597995/a7bbf778-5ff8-11e6-88c8-07a4d4f9fd84.png">

Also: `success`, `warnings`, `errors` and `info` now has different icons:
<img width="1176" alt="screenshot 2016-08-11 19 09 04" src="https://cloud.githubusercontent.com/assets/3471625/17598016/d0e89a0c-5ff8-11e6-9c07-9c7be9f3161b.png">
<img width="1176" alt="screenshot 2016-08-11 19 12 42" src="https://cloud.githubusercontent.com/assets/3471625/17598018/d45b031e-5ff8-11e6-8ba5-7560fcf8491e.png">
<img width="1176" alt="screenshot 2016-08-11 19 24 41" src="https://cloud.githubusercontent.com/assets/3471625/17598156/77563b24-5ff9-11e6-853a-19f4adec9167.png">
## References

No jira task :/
