### PR TITLE
Remove 'invalid date' in birth field for new users

### DIFF
--- a/.lgtm
+++ b/.lgtm
@@ -1,2 +1,2 @@
-approvals = 4
+approvals = 2
 pattern = "(?i):shipit:|:\\+1:|LGTM"

--- a/src/commons/trip/editTrip.jsx
+++ b/src/commons/trip/editTrip.jsx
@@ -71,6 +71,9 @@ function EditTrip(props) {
         );
     }
 
+    const maxDate = this.props.destination.endDate ?
+            moment(this.props.destination.endDate) : null;
+
     return (
         <Segment>
             <Form
@@ -82,6 +85,7 @@ function EditTrip(props) {
                     label="Start date. This can only be changed by an admin.
                     Contact us if you have problems!"
                     minDate={moment()}
+                    maxDate={maxDate}
                     id="startDate"
                     allowNullValue
                     disabled={!props.editAdmin}
@@ -91,8 +95,7 @@ function EditTrip(props) {
                 <DateField
                     label="End date (optional)"
                     minDate={moment(startDate.value) || moment()}
-                    maxDate={props.destination.endDate ?
-                            moment(props.destination.endDate) : null}
+                    maxDate={maxDate}
                     allowNullValue
                     id="endDate"
                 >
@@ -101,8 +104,7 @@ function EditTrip(props) {
                 <DateField
                     label="Date of arrival at destination"
                     minDate={moment(startDate.value) || moment()}
-                    maxDate={props.destination.endDate ?
-                            moment(props.destination.endDate) : null}
+                    maxDate={moment(endDate.value)}
                     allowNullValue
                     id="arrivalDate"
                     required

--- a/src/commons/user/editUser.jsx
+++ b/src/commons/user/editUser.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import { reduxForm } from 'redux-form';
+import moment from 'moment';
 
 import Form from '../Form';
 import Button from '../Button';
@@ -34,6 +35,9 @@ const validate = values => {
     if (!values.birth) {
         errors.birth = 'Required';
     }
+    if (values.birth && !moment(values.birth).isValid()) {
+        errors.birth = 'The date has to be written on the format YYYY-MM-DD';
+    }
     if (!values.volunteerInfo) {
         errors.volunteerInfo = 'Required. Please tell us about yourself!';
     }
@@ -51,6 +55,7 @@ const renderIfFieldIsFilled = (field, element) => {
     if (field.value && field.value.length > 0) return element;
     return '';
 };
+let firstRenderIsDone = false; // Set to true on first render
 
 function EditUser(props) {
     const {
@@ -64,6 +69,14 @@ function EditUser(props) {
         errorMessage,
         isFetching
     } = props;
+
+    if (!birth.valid && !firstRenderIsDone) {
+        birth.value = ''; // Remove 'Invalid date' for new users
+    }
+
+    if (!firstRenderIsDone) {
+        firstRenderIsDone = true;
+    }
 
     return (
         <Segment>
@@ -97,12 +110,17 @@ function EditUser(props) {
                     placeholder="YYYY-MM-DD"
                     required
                 >
-                    {birth}
+                {birth}
                 </InputField>
                 <InputField label="E-mail" type="email" required>
                     {email}
                 </InputField>
-                <InputField label="Phone number" type="tel" required>
+                <InputField
+                    label="Phone number (include the country code in front of the number)"
+                    type="tel"
+                    placeholder="+0012345678"
+                    required
+                >
                     {phoneNumber}
                 </InputField>
                 <SelectField
@@ -196,7 +214,8 @@ function EditUser(props) {
                 <TextField
                     rows={3}
                     label="Work and experience"
-                    placeholder="Fill in your occupation, work experience and/or other information you find relevant"
+                    placeholder={`Fill in your occupation, work experience and/or
+                    other information you find relevant`}
                     required
                 >
                     {volunteerInfo}

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,6 +6,13 @@ const countries = require('json!./countries.json'); // eslint-disable-line
 * @module components/constants
 */
 
+
+/**
+* Preferred format of moment dates
+* @type {string} Date format
+*/
+export const DATE_FORMAT = 'YYYY-MM-DD';
+
 /**
 * The possible roles a user can have.
 * @type {object}

--- a/src/sections/profile/index.jsx
+++ b/src/sections/profile/index.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { browserHistory } from 'react-router';
 import moment from 'moment';
 
+import { DATE_FORMAT } from '../../constants';
 import { update, retrieve } from '../../actions/accountActions';
 import { pushNotification } from '../../actions/notificationActions';
 import Header from '../../commons/pageHeader';
@@ -47,14 +48,20 @@ class Profile extends Component {
     }
 
     onUpdate(data) {
-        this.handlers.update(data)
+        this.handlers.update({
+            ...data,
+            birth: moment(data.birth).toString()
+        })
         .then(() => this.handlers.retrieve())
         .then(() => this.handlers.notification('Profile is updated.', 'success'))
         .then(() => browserHistory.push('/profile'));
     }
 
     prepareInitialValues(account) {
-        return { ...account, birth: moment(account.birth).format('YYYY-MM-DD') };
+        return {
+            ...account,
+            birth: moment(account.birth).format(DATE_FORMAT)
+        };
     }
 
     render() {


### PR DESCRIPTION
## At a glance
- Removes the Moment-error 'Invalid date' in the date field for new users
- Moment validation of the date (checks if the string gives a valid moment date)
- Placeholder for phone number an note that it needs to include country code
- Date format for moment in constants
- Reduce the number of LGTMs to 2 for the fall (two of us are going to develop more)
- Trip start date not allowed to be after destination end date, see [DIH-361](https://jira.capraconsulting.no/browse/DIH-361). **Note:** The issue is regarding departure date, but that's not used anymore so I simply did this. What do you guys think? I also think this is what [DIH-362](https://jira.capraconsulting.no/browse/DIH-362) is about - a trip isn't active nor inactive so this is also about destination dates?
## References
- See [DIH-393](https://jira.capraconsulting.no/browse/DIH-393)
- See [DIH-361](https://jira.capraconsulting.no/browse/DIH-361)

@larseen @scbasma You guys should look this over
