### PR TITLE
Add missing form values

### DIFF
--- a/src/commons/trip/tripInfo.jsx
+++ b/src/commons/trip/tripInfo.jsx
@@ -17,7 +17,7 @@ const TripInfo = (props) => (
                 icon="circle"
                 content={TRIP_STATUS_LABELS[props.trip.status]}
             />
-            <ListItem
+            <FluidListItem
                 name="Comment on status"
                 icon="tag"
                 content={props.trip.statusComment}

--- a/src/commons/trip/tripInfo.jsx
+++ b/src/commons/trip/tripInfo.jsx
@@ -18,6 +18,11 @@ const TripInfo = (props) => (
                 content={TRIP_STATUS_LABELS[props.trip.status]}
             />
             <ListItem
+                name="Comment on status"
+                icon="tag"
+                content={props.trip.statusComment}
+            />
+            <ListItem
                 name="Start date"
                 icon="calendar"
                 content={props.trip.startDate ?

--- a/src/commons/trip/tripInfo.jsx
+++ b/src/commons/trip/tripInfo.jsx
@@ -1,11 +1,11 @@
 import React, { PropTypes } from 'react';
+import moment from 'moment';
 
-import { TRAVEL_METHODS, TRIP_STATUS_LABELS } from '../../constants';
+import { TRAVEL_METHODS, TRIP_STATUS_LABELS, TRIP_STATUSES } from '../../constants';
 import List from '../list';
 import Segment from '../Segment';
 import ListItem from '../list/listItem';
 import FluidListItem from '../list/fluidListItem';
-import moment from 'moment';
 
 const MOMENT_FORMAT = 'YYYY-MM-DD';
 
@@ -35,10 +35,17 @@ const TripInfo = (props) => (
                     moment(props.trip.endDate).format(MOMENT_FORMAT) : 'Not set'}
             />
             <ListItem
-                name="Date of arrival at destination"
+                name="Date the volunteer arrived at the destination"
+                hidden={props.trip.status !== TRIP_STATUSES.PRESENT &&
+                props.trip.status !== TRIP_STATUSES.LEFT}
                 icon="calendar"
-                content={props.trip.arrivalDate ?
-                    moment(props.trip.arrivalDate).format(MOMENT_FORMAT) : 'Not set'}
+                content={moment(props.trip.dateArrived).format(MOMENT_FORMAT)}
+            />
+            <ListItem
+                name="Date the volunteer left the destination"
+                hidden={props.trip.status !== TRIP_STATUSES.LEFT}
+                icon="calendar"
+                content={moment(props.trip.dateLeft).format(MOMENT_FORMAT)}
             />
             <ListItem
                 name="Method of travel"

--- a/src/commons/user/editUser.jsx
+++ b/src/commons/user/editUser.jsx
@@ -95,14 +95,22 @@ function EditUser(props) {
                 <InputField
                     label="Date of birth (YYYY-MM-DD)"
                     placeholder="YYYY-MM-DD"
-                    required
+                    required={props.user.role !== USER_ROLES.ADMIN}
                 >
                     {birth}
                 </InputField>
-                <InputField label="E-mail" type="email" required>
+                <InputField
+                    label="E-mail"
+                    type="email"
+                    required={props.user.role !== USER_ROLES.ADMIN}
+                >
                     {email}
                 </InputField>
-                <InputField label="Phone number" type="tel" required>
+                <InputField
+                    label="Phone number"
+                    type="tel"
+                    required={props.user.role !== USER_ROLES.ADMIN}
+                >
                     {phoneNumber}
                 </InputField>
                 <SelectField
@@ -197,7 +205,7 @@ function EditUser(props) {
                     rows={3}
                     label="Work and experience"
                     placeholder="Fill in your occupation, work experience and/or other information you find relevant"
-                    required
+                    required={props.user.role !== USER_ROLES.ADMIN}
                 >
                     {volunteerInfo}
                 </TextField>
@@ -218,7 +226,6 @@ function EditUser(props) {
                         <a target="_blank" rel="noopener noreferrer" href="http://www.drapenihavet.no/en/guidelines">
                         Click here to read the guidelines.</a>`}
                         id="readTerms"
-                        required
                     >
                         {readTerms}
                     </ToggleField>
@@ -229,7 +236,7 @@ function EditUser(props) {
                         <a target="_blank" rel="noopener noreferrer" href="http://www.drapenihavet.no/en/guidelines">
                         Click here to read the guidelines.</a>`}
                         id="readTerms"
-                        required
+                        required={props.user.role !== USER_ROLES.ADMIN}
                     >
                         {readTerms}
                     </ToggleField>
@@ -256,7 +263,8 @@ EditUser.propTypes = {
     handleSubmit: PropTypes.func.isRequired,
     isFetching: PropTypes.bool,
     submitting: PropTypes.bool.isRequired,
-    showAdminFields: PropTypes.bool
+    showAdminFields: PropTypes.bool,
+    user: PropTypes.object
 };
 
 export default reduxForm({

--- a/src/sections/admin/destinations/addDestinationForm.jsx
+++ b/src/sections/admin/destinations/addDestinationForm.jsx
@@ -1,11 +1,14 @@
 import React, { PropTypes } from 'react';
 import { reduxForm } from 'redux-form';
+import moment from 'moment';
 
 import Button from '../../../commons/Button';
 import Form from '../../../commons/Form';
 import InputField from '../../../commons/Form/InputField';
+import DateField from '../../../commons/Form/DateField';
 
-const fields = ['name', 'minimumTripDurationInDays'];
+
+const fields = ['name', 'minimumTripDurationInDays', 'startDate', 'endDate'];
 
 const validate = values => {
     const errors = {};
@@ -15,9 +18,10 @@ const validate = values => {
     return errors;
 };
 
+
 function AddDestinationForm(props) {
     const {
-        fields: { name, minimumTripDurationInDays },
+        fields: { name, startDate, endDate, minimumTripDurationInDays },
         errorMessage,
         handleSubmit,
         isFetching
@@ -32,6 +36,21 @@ function AddDestinationForm(props) {
             <InputField label="Name" type="text" required>
                 {name}
             </InputField>
+            <DateField
+                label="Destination start date"
+                minDate={moment()}
+                id="startDate"
+            >
+                {startDate}
+            </DateField>
+            <DateField
+                label="End date (optional)"
+                minDate={startDate.value ? moment(startDate.value) : moment()}
+                allowNullValue
+                id="endDate"
+            >
+                {endDate}
+            </DateField>
             <InputField
                 label="Minium trip duration (in days)"
                 type="number"

--- a/src/sections/admin/trips/trip/index.jsx
+++ b/src/sections/admin/trips/trip/index.jsx
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
+import { browserHistory } from 'react-router';
 
 import Header from '../../../../commons/pageHeader';
 import Segments from '../../../../commons/Segments';
@@ -64,6 +65,7 @@ class Trip extends Component {
                 const message = 'Trip changes saved!';
                 const { error } = response;
                 if (!error) this.handlers.notification(message, 'success');
+                browserHistory.push('/admin/trips');
                 return this.handlers.retrieve(this.props.params.tripId);
             });
     }

--- a/src/sections/admin/trips/trip/tripStatus.jsx
+++ b/src/sections/admin/trips/trip/tripStatus.jsx
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import { reduxForm } from 'redux-form';
 import { connect } from 'react-redux';
+import moment from 'moment';
 import _ from 'lodash';
 import TextField from '../../../../commons/Form/TextField';
 import SelectField from '../../../../commons/Form/SelectField';
@@ -110,6 +111,12 @@ class UpdateTripStatus extends Component {
             statusComment: this.props.fields.statusComment.value,
             id: this.props.trip.id
         };
+        if (body.status === TRIP_STATUSES.LEFT) {
+            body.dateLeft = moment();
+        }
+        if (body.status === TRIP_STATUSES.PRESENT) {
+            body.dateArrived = moment();
+        }
         this.handlers.update(body)
             .then(() => this.handlers.retrieve(this.props.params.tripId))
             .then(response => {


### PR DESCRIPTION
## At a glance
- Add status comment to trip view
- Remove required for admin on edit user
- Add startDate and endDate to Add destination
- Add dateArrived and dateLeft to admin view of trip: dateArrived is shown when status is set to `PRESENT`, and both are shown when status is set to `LEFT`
- Redirect to `/admin/trips` on trip save 
## Screenshots

![image](https://cloud.githubusercontent.com/assets/1620267/17651485/4853995e-6268-11e6-8a3d-dd2dde762ae9.png)
![image](https://cloud.githubusercontent.com/assets/1620267/17651492/68c7a32e-6268-11e6-9dea-d0015cfe79ac.png)
![image](https://cloud.githubusercontent.com/assets/1620267/17651694/b52ab57c-626c-11e6-8f46-cb467b0e95a2.png)
## References

[DIH-381](https://jira.capraconsulting.no/browse/DIH-381), [DIH-384](https://jira.capraconsulting.no/browse/DIH-384), [DIH-387](https://jira.capraconsulting.no/browse/DIH-387), [DIH-394](https://jira.capraconsulting.no/browse/DIH-394)

@scbasma @larseen 
