### PR TITLE
[Doppins] Upgrade dependency lodash to 4.16.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "axios": "0.12.0",
     "draft-js": "0.7.0",
     "json-loader": "^0.5.4",
-    "lodash": "4.16.1",
+    "lodash": "4.16.2",
     "moment": "2.13.0",
     "normalize.css": "4.2.0",
     "raven-js": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "axios": "0.12.0",
     "draft-js": "0.7.0",
     "json-loader": "^0.5.4",
-    "lodash": "4.13.1",
+    "lodash": "4.15.0",
     "moment": "2.13.0",
     "normalize.css": "4.2.0",
     "raven-js": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "axios": "0.12.0",
     "draft-js": "0.7.0",
     "json-loader": "^0.5.4",
-    "lodash": "4.16.0",
+    "lodash": "4.16.1",
     "moment": "2.13.0",
     "normalize.css": "4.2.0",
     "raven-js": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "axios": "0.12.0",
     "draft-js": "0.7.0",
     "json-loader": "^0.5.4",
-    "lodash": "4.15.0",
+    "lodash": "4.16.0",
     "moment": "2.13.0",
     "normalize.css": "4.2.0",
     "raven-js": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "axios": "0.12.0",
     "draft-js": "0.7.0",
     "json-loader": "^0.5.4",
-    "lodash": "4.16.3",
+    "lodash": "4.16.4",
     "moment": "2.13.0",
     "normalize.css": "4.2.0",
     "raven-js": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "axios": "0.12.0",
     "draft-js": "0.7.0",
     "json-loader": "^0.5.4",
-    "lodash": "4.16.2",
+    "lodash": "4.16.3",
     "moment": "2.13.0",
     "normalize.css": "4.2.0",
     "raven-js": "3.3.0",


### PR DESCRIPTION
Hi!

A new version was just released of `lodash`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded lodash from `4.13.1` to `4.15.0`
