### PR TITLE
[Doppins] Upgrade dependency draft-js to 0.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   },
   "dependencies": {
     "axios": "0.12.0",
-    "draft-js": "0.9.0",
+    "draft-js": "0.9.1",
     "json-loader": "^0.5.4",
     "lodash": "4.13.1",
     "moment": "2.13.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   },
   "dependencies": {
     "axios": "0.12.0",
-    "draft-js": "0.9.1",
+    "draft-js": "0.10.0",
     "json-loader": "^0.5.4",
     "lodash": "4.13.1",
     "moment": "2.13.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   },
   "dependencies": {
     "axios": "0.12.0",
-    "draft-js": "0.7.0",
+    "draft-js": "0.8.1",
     "json-loader": "^0.5.4",
     "lodash": "4.13.1",
     "moment": "2.13.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   },
   "dependencies": {
     "axios": "0.12.0",
-    "draft-js": "0.8.1",
+    "draft-js": "0.9.0",
     "json-loader": "^0.5.4",
     "lodash": "4.13.1",
     "moment": "2.13.0",


### PR DESCRIPTION
Hi!

A new version was just released of `draft-js`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded draft-js from `0.7.0` to `0.8.1`
#### Changelog:
#### Version 0.8.1
### Fixed
- Include `object-assign` in npm dependencies
- Include `babel-core` in npm dependencies of tex example
#### Version 0.8.0
### Added
- `customStyleFn` for more control over inline style ranges
- Uses `internalClipboard` for Safari
- Metadata for `ContentBlock` objects
- `convertFromHTMLToContentBlocks`:
  - Support for `mailto` protocol for links
  - Support "unset" inline styles
- Run ESLint on examples
### Changed
- Removed redundant ESLint module in TeX example
- Update Travis CI config for readability, Node v4 requirements, and pruning/updating npm dependencies
- Use `immutable` ~3.7.4 to avoid Flow errors in updated versions
- Modify `getSelectionOffsetKeyForNode` to search for nested offset-annotated nodes
- Upgrade eslint to 3.0.1, use fbjs config
- Update to Flow 0.28
- Jest
  - Update to 12.1.1
  - Replaced `jest.fn().mockReturnValue(x)` with `jest.fn(() => x)`
- Remove extra spaces from the text decoration style
- No longer using `nullthrows` for `blockRenderMap`
- `convertFromHTMLToContentBlocks`:
  - Improved variable names in `joinChunks`
  - Additional whitelisted entities such as `className`, `rel`, `target`, `title`
### Fixed
- Fix bug where placeholder text was not being erased in Chrome
- Fix bug where double click link in Firefox broke selection
- Kill iOS tooltips
- removed unnecessary `undefined` checks on `DraftEditorLeaf`
- `convertFromHTMLToContentBlocks`:
  - Preserve pasted block type on paste
  - Strip XML carriage returns and zero-width spaces
  - `getBlockMapSupportedTags()` will always return a valid array of tags
- Documentation fixes
