### PR TITLE
[Doppins] Upgrade dependency raven-js to 3.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "lodash": "4.13.1",
     "moment": "2.13.0",
     "normalize.css": "4.2.0",
-    "raven-js": "3.5.1",
+    "raven-js": "3.7.0",
     "react": "15.1.0",
     "react-addons-update": "15.1.0",
     "react-breadcrumbs": "1.3.16",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "lodash": "4.13.1",
     "moment": "2.13.0",
     "normalize.css": "4.2.0",
-    "raven-js": "3.3.0",
+    "raven-js": "3.5.1",
     "react": "15.1.0",
     "react-addons-update": "15.1.0",
     "react-breadcrumbs": "1.3.16",


### PR DESCRIPTION
Hi!

A new version was just released of `raven-js`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded raven-js from `3.3.0` to `3.5.1`
#### Changelog:
#### Version 3.5.1
- BUGFIX: Fix non-fatals crashing React Native plugin unless `shouldSendCallback` is specified. See: `https://github.com/getsentry/raven-js/pull/694`
#### Version 3.5.0
- NEW: Can now disable automatic collection of breadcrumbs via `autoBreadcrumbs` config option. See: `https://github.com/getsentry/raven-js/pull/686`
- NEW: Can now configure max number of breadcrumbs to collect via `maxBreadcrumbs`. See: `https://github.com/getsentry/raven-js/pull/685`
- NEW: Added Vue.js plugin. See: `https://github.com/getsentry/raven-js/pull/688`
- CHANGE: Raven.js now collects 100 breadcrumbs by default. See: `https://github.com/getsentry/raven-js/pull/685`
- CHANGE: React Native plugin now also normalizes paths from CodePush. See: `https://github.com/getsentry/raven-js/pull/683`
#### Version 3.4.1
- BUGFIX: Fix exception breadcrumbs having "undefined" for exception value. See: `https://github.com/getsentry/raven-js/pull/681`
#### Version 3.4.0
- CHANGE: React Native plugin now stores errors in AsyncStorage and sends error data on app init. See: `https://github.com/getsentry/raven-js/pull/626`
- BUGFIX: React Native path normalization regex has been updated. See: `https://github.com/getsentry/raven-js/pull/666`
- BUGFIX: Angular 1 plugin now extracts errors from minified exception strings. See: `https://github.com/getsentry/raven-js/pull/667`
