### PR TITLE
[Doppins] Upgrade dependency jsonwebtoken to ~7.1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "file-loader": "~0.9.0",
     "html-webpack-plugin": "~2.21.0",
     "http-proxy-middleware": "~0.16.0",
-    "jsonwebtoken": "~7.0.1",
+    "jsonwebtoken": "~7.1.9",
     "node-libs-browser": "~1.0.0",
     "node-sass": "~3.8.0",
     "object-assign": "~4.1.0",


### PR DESCRIPTION
Hi!

A new version was just released of `jsonwebtoken`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded jsonwebtoken from `~7.0.1` to `~7.1.9`
