### PR TITLE
[Doppins] Upgrade dependency eslint to ~3.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "copy-webpack-plugin": "~3.0.1",
     "css-loader": "~0.23.1",
     "cucumber": "~0.10.2",
-    "eslint": "~2.13.1",
+    "eslint": "~3.3.1",
     "eslint-config-airbnb": "~9.0.1",
     "eslint-plugin-import": "~1.9.2",
     "eslint-plugin-jsx-a11y": "~1.5.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "copy-webpack-plugin": "~3.0.1",
     "css-loader": "~0.23.1",
     "cucumber": "~0.10.2",
-    "eslint": "~3.7.1",
+    "eslint": "~3.8.0",
     "eslint-config-airbnb": "~9.0.1",
     "eslint-plugin-import": "~1.9.2",
     "eslint-plugin-jsx-a11y": "~1.5.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "copy-webpack-plugin": "~3.0.1",
     "css-loader": "~0.23.1",
     "cucumber": "~0.10.2",
-    "eslint": "~3.7.0",
+    "eslint": "~3.7.1",
     "eslint-config-airbnb": "~9.0.1",
     "eslint-plugin-import": "~1.9.2",
     "eslint-plugin-jsx-a11y": "~1.5.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "copy-webpack-plugin": "~3.0.1",
     "css-loader": "~0.23.1",
     "cucumber": "~0.10.2",
-    "eslint": "~3.5.0",
+    "eslint": "~3.6.0",
     "eslint-config-airbnb": "~9.0.1",
     "eslint-plugin-import": "~1.9.2",
     "eslint-plugin-jsx-a11y": "~1.5.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "copy-webpack-plugin": "~3.0.1",
     "css-loader": "~0.23.1",
     "cucumber": "~0.10.2",
-    "eslint": "~3.6.1",
+    "eslint": "~3.7.0",
     "eslint-config-airbnb": "~9.0.1",
     "eslint-plugin-import": "~1.9.2",
     "eslint-plugin-jsx-a11y": "~1.5.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "copy-webpack-plugin": "~3.0.1",
     "css-loader": "~0.23.1",
     "cucumber": "~0.10.2",
-    "eslint": "~3.3.1",
+    "eslint": "~3.5.0",
     "eslint-config-airbnb": "~9.0.1",
     "eslint-plugin-import": "~1.9.2",
     "eslint-plugin-jsx-a11y": "~1.5.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "copy-webpack-plugin": "~3.0.1",
     "css-loader": "~0.23.1",
     "cucumber": "~0.10.2",
-    "eslint": "~3.6.0",
+    "eslint": "~3.6.1",
     "eslint-config-airbnb": "~9.0.1",
     "eslint-plugin-import": "~1.9.2",
     "eslint-plugin-jsx-a11y": "~1.5.3",


### PR DESCRIPTION
Hi!

A new version was just released of `eslint`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded eslint from `~2.13.1` to `~3.3.1`
#### Changelog:
#### Version 3.3.1
- a2f06be Build: optimize rule page title for small browser tabs (fixes `#6888`) (`#6904`) (Vitor Balocco)
- 02a00d6 Docs: clarify rule details for no-template-curly-in-string (`#6900`) (not-an-aardvark)
- b9b3446 Fix: sort-keys ignores destructuring patterns (fixes `#6896`) (`#6899`) (Kai Cataldo)
- 3fe3a4f Docs: Update options in `object-shorthand` (`#6898`) (Grant Snodgrass)
- cd09c96 Chore: Use object-shorthand batch 2 (refs `#6407`) (`#6897`) (Kai Cataldo)
- 2841008 Chore: Use object-shorthand batch 1 (refs `#6407`) (`#6893`) (Kai Cataldo)
#### Version 3.3.0
- 683ac56 Build: Add CI release scripts (fixes `#6884`) (`#6885`) (Nicholas C. Zakas)
- ebf8441 Update: `prefer-rest-params` relax for member accesses (fixes `#5990`) (`#6871`) (Toru Nagashima)
- df01c4f Update: Add regex support for exceptions (fixes `#5187`) (`#6883`) (Annie Zhang)
- 055742c Fix: `no-dupe-keys` type errors (fixes `#6886`) (`#6889`) (Toru Nagashima)
- e456fd3 New: `sort-keys` rule (fixes `#6076`) (`#6800`) (Toru Nagashima)
- 3e879fc Update: Rule "eqeqeq" to have more specific null handling (fixes `#6543`) (`#6849`) (Simon Sturmer)
- e8cb7f9 Chore: use eslint-plugin-node (refs `#6407`) (`#6862`) (Toru Nagashima)
- e37bbd8 Docs: Remove duplicate statement (`#6878`) (Richard Käll)
- 11395ca Fix: `no-dupe-keys` false negative (fixes `#6801`) (`#6863`) (Toru Nagashima)
- 1ecd2a3 Update: improve error message in `no-control-regex` (`#6839`) (Jordan Harband)
- d610d6c Update: make `max-lines` report the actual number of lines (fixes `#6766`) (`#6764`) (Jarek Rencz)
- b256c50 Chore: Fix glob for core js files for lint (fixes `#6870`) (`#6872`) (Gyandeep Singh)
- f8ab8f1 New: func-call-spacing rule (fixes `#6080`) (`#6749`) (Brandon Mills)
- be68f0b New: no-template-curly-in-string rule (fixes `#6186`) (`#6767`) (Jeroen Engels)
- 80789ab Chore: don't throw if rule is in old format (fixes `#6848`) (`#6850`) (Vitor Balocco)
- d47c505 Fix: `newline-after-var` false positive (fixes `#6834`) (`#6847`) (Toru Nagashima)
- bf0afcb Update: validate void operator in no-constant-condition (fixes `#5726`) (`#6837`) (Vitor Balocco)
- 5ef839e New: Add consistent and ..-as-needed to object-shorthand (fixes `#5438`) (`#5439`) (Martijn de Haan)
- 7e1bf01 Fix: update peerDependencies of airbnb option for `--init` (fixes `#6843`) (`#6846`) (Vitor Balocco)
- 8581f4f Fix: `no-invalid-this` false positive (fixes `#6824`) (`#6827`) (Toru Nagashima)
- 90f78f4 Update: add `props` option to `no-self-assign` rule (fixes `#6718`) (`#6721`) (Toru Nagashima)
- 30d71d6 Update: 'requireForBlockBody' modifier for 'arrow-parens' (fixes `#6557`) (`#6558`) (Nicolas Froidure)
- cdded07 Chore: use native `Object.assign` (refs `#6407`) (`#6832`) (Gyandeep Singh)
- 579ec49 Chore: Add link to rule change guidelines in "needs info" template (fixes `#6829`) (`#6831`) (Kevin Partington)
- 117e7aa Docs: Remove incorrect "constructor" statement from `no-new-symbol` docs (`#6830`) (Jarek Rencz)
- aef18b4 New: `no-unsafe-negation` rule (fixes `#2716`) (`#6789`) (Toru Nagashima)
- d94e945 Docs: Update Getting Started w/ Readme installation instructions (`#6823`) (Kai Cataldo)
- dfbc112 Upgrade: proxyquire to 1.7.10 (fixes `#6821`) (`#6822`) (alberto)
- 4c5e911 Chore: enable `prefer-const` and apply it to our codebase (refs `#6407`) (`#6805`) (Toru Nagashima)
- e524d16 Update: camelcase rule fix for import declarations (fixes `#6755`) (`#6784`) (Lorenzo Zottar)
- 8f3509d Update: make `eslint:all` excluding deprecated rules (fixes `#6734`) (`#6756`) (Toru Nagashima)
- 2b17459 New: `no-global-assign` rule (fixes `#6586`) (`#6746`) (alberto)
#### Version 3.2.2
- 510ce4b Upgrade: file-entry-cache@^1.3.1 (fixes `#6816`, refs `#6780`) (`#6819`) (alberto)
- 46b14cd Fix: ignore MemberExpression in VariableDeclarators (fixes `#6795`) (`#6815`) (Nicholas C. Zakas)
#### Version 3.2.1
- 584577a Build: Pin file-entry-cache to avoid licence issue (refs `#6816`) (`#6818`) (alberto)
- 38d0d23 Docs: clarify minor releases and suggest using `~ to version (`#6804`) (Henry Zhu)
- 4ca809e Fix: Normalizes messages so all end with a period (fixes `#6762`) (`#6807`) (Patrick McElhaney)
- c7488ac Fix: Make MemberExpression option opt-in (fixes `#6797`) (`#6798`) (Rich Trott)
- 715e8fa Docs: Update issue closing policy (fixes `#6765`) (`#6808`) (Nicholas C. Zakas)
- 288f7bf Build: Fix site generation (fixes `#6791`) (`#6793`) (Nicholas C. Zakas)
- 261a9f3 Docs: Update JSCS status in README (`#6802`) (alberto)
- 5ae0887 Docs: Update no-void.md (`#6799`) (Daniel Hritzkiv)
#### Version 3.2.0
- 2438ee2 Upgrade: Update markdownlint dependency to 0.2.0 (fixes `#6781`) (`#6782`) (David Anson)
- 4fc0018 Chore: dogfooding `no-var` rule and remove `var`s (refs `#6407`) (`#6757`) (Toru Nagashima)
- b22eb5c New: `no-tabs` rule (fixes `#6079`) (`#6772`) (Gyandeep Singh)
- ddea63a Chore: Updated no-control-regex tests to cover all cases (fixes `#6438`) (`#6752`) (Efe Gürkan YALAMAN)
- 1025772 Docs: Add plugin example to disabling with comments guide (fixes `#6742`) (`#6747`) (Brandon Mills)
- 628aae4 Docs: fix inconsistent spacing inside block comment (`#6768`) (Brian Jacobel)
- 2983c32 Docs: Add options to func-names config comments (`#6748`) (Brandon Mills)
- 2f94443 Docs: fix wrong path (`#6763`) (molee1905)
- 6f3faa4 Revert "Build: Remove support for Node v5 (fixes `#6743`)" (`#6758`) (Nicholas C. Zakas)
- 99dfd1c Docs: fix grammar issue in rule-changes page (`#6761`) (Vitor Balocco)
- e825458 Fix: Rule no-unused-vars had missing period (fixes `#6738`) (`#6739`) (Brian Mock)
- 71ae64c Docs: Clarify cache file deletion (fixes `#4943`) (`#6712`) (Nicholas C. Zakas)
- 26c85dd Update: merge warnings of consecutive unreachable nodes (fixes `#6583`) (`#6729`) (Toru Nagashima)
- 106e40b Fix: Correct grammar in object-curly-newline reports (fixes `#6725`) (`#6728`) (Vitor Balocco)
- e00754c Chore: Dogfooding ES6 rules (refs `#6407`) (`#6735`) (alberto)
- 181b26a Build: Remove support for Node v5 (fixes `#6743`) (`#6744`) (alberto)
- 5320a6c Update: `no-use-before-define` false negative on for-in/of (fixes `#6699`) (`#6719`) (Toru Nagashima)
- a2090cb Fix: space-infix-ops doesn't fail for  type annotations(fixes `#5211`) (`#6723`) (Nicholas C. Zakas)
- 9c36ecf Docs: Add `@vitorbal` and `@platinumazure` to development team (Ilya Volodin)
- e09d1b8 Docs: describe all RuleTester options (fixes `#4810`, fixes `#6709`) (`#6711`) (Nicholas C. Zakas)
- a157f47 Chore: Update CLIEngine option desc (fixes `#5179`) (`#6713`) (Nicholas C. Zakas)
- a0727f9 Chore: fix `.gitignore` for vscode (refs `#6383`) (`#6720`) (Toru Nagashima)
- 75d2d43 Docs: Clarify Closure type hint expectation (fixes `#5231`) (`#6714`) (Nicholas C. Zakas)
- 95ea25a Update: Check indentation of multi-line chained properties (refs `#1801`) (`#5940`) (Rich Trott)
- e7b1e1c Docs: Edit issue/PR waiting period docs (fixes `#6009`) (`#6715`) (Nicholas C. Zakas)
- 053aa0c Update: Added 'allowSuper' option to `no-underscore-dangle` (fixes `#6355`) (`#6662`) (peteward44)
- 8929045 Build: Automatically generate rule index (refs `#2860`) (`#6658`) (Ilya Volodin)
- f916ae5 Docs: Fix multiline-ternary typos (`#6704`) (Cédric Malard)
- c64b0c2 Chore: First ES6 refactoring (refs `#6407`) (`#6570`) (Nicholas C. Zakas)
#### Version 3.1.1
- 565e584 Fix: `eslint:all` causes regression in 3.1.0 (fixes `#6687`) (`#6696`) (alberto)
- cb90359 Fix: Allow named recursive functions (fixes `#6616`) (`#6667`) (alberto)
- 3f206dd Fix: `balanced` false positive in `spaced-comment` (fixes `#6689`) (`#6692`) (Grant Snodgrass)
- 57f1676 Docs: Add missing brackets from code examples (`#6700`) (Plusb Preco)
- 124f066 Chore: Remove fixable key from multiline-ternary metadata (fixes `#6683`) (`#6688`) (Kai Cataldo)
- 9f96086 Fix: Escape control characters in XML. (fixes `#6673`) (`#6672`) (George Chung)
#### Version 3.1.0
- e8f8c6c Fix: incorrect exitCode when eslint is called with --stdin (fixes `#6677`) (`#6682`) (Steven Humphrey)
- 38639bf Update: make `no-var` fixable (fixes `#6639`) (`#6644`) (Toru Nagashima)
- dfc20e9 Fix: `no-unused-vars` false positive in loop (fixes `#6646`) (`#6649`) (Toru Nagashima)
- 2ba75d5 Update: relax outerIIFEBody definition (fixes `#6613`) (`#6653`) (Stephen E. Baker)
- 421e4bf Chore: combine multiple RegEx replaces with one (fixes `#6669`) (`#6661`) (Sakthipriyan Vairamani)
- 089ee2c Docs: fix typos,wrong path,backticks (`#6663`) (molee1905)
- ef827d2 Docs: Add another pre-commit hook to integrations (`#6666`) (David Alan Hjelle)
- a343b3c Docs: Fix option typo in no-underscore-dangle (Fixes `#6674`) (`#6675`) (Luke Page)
- 5985eb2 Chore: add internal rule that validates meta property (fixes `#6383`) (`#6608`) (Vitor Balocco)
- 4adb15f Update: Add `balanced` option to `spaced-comment` (fixes `#4133`) (`#6575`) (Annie Zhang)
- 1b13c25 Docs: fix incorrect example being mark as correct (`#6660`) (David Björklund)
- a8b4e40 Fix: Install required eslint plugin for "standard" guide (fixes `#6656`) (`#6657`) (Feross Aboukhadijeh)
- 720686b New: `endLine` and `endColumn` of the lint result. (refs `#3307`) (`#6640`) (Toru Nagashima)
- 54faa46 Docs: Small tweaks to CLI documentation (fixes `#6627`) (`#6642`) (Kevin Partington)
- e108850 Docs: Added examples and structure to `padded-blocks` (fixes `#6628`) (`#6643`) (alberto)
- 350e1c0 Docs: Typo (`#6650`) (Peter Rood)
- b837c92 Docs: Correct a term in max-len.md (fixes `#6637`) (`#6641`) (Vse Mozhet Byt)
- baeb313 Fix: Warning behavior for executeOnText (fixes `#6611`) (`#6632`) (Nicholas C. Zakas)
- e6004be Chore: Enable preferType in valid-jsdoc (refs `#5188`) (`#6634`) (Nicholas C. Zakas)
- ca323cf Fix: Use default assertion messages (fixes `#6532`) (`#6615`) (Dmitrii Abramov)
- 2bdf22c Fix: Do not throw exception if baseConfig is provided (fixes `#6605`) (`#6625`) (Kevin Partington)
- e42cacb Upgrade: mock-fs to 3.10, fixes for Node 6.3 (fixes `#6621`) (`#6624`) (Tim Schaub)
- 8a263ae New: multiline-ternary rule (fixes `#6066`) (`#6590`) (Kai Cataldo)
- e951303 Update: Adding new `key-spacing` option (fixes `#5613`) (`#5907`) (Kyle Mendes)
- 10c3e91 Docs: Remove reference from 3.0.0 migration guide (refs `#6605`) (`#6618`) (Kevin Partington)
- 5010694 Docs: Removed non-existing resource (`#6609`) (Moritz Kröger)
- 6d40d85 Docs: Note that PR requires ACCEPTED issue (refs `#6568`) (`#6604`) (Patrick McElhaney)
#### Version 3.0.1
- 27700cf Fix: `no-unused-vars` false positive around callback (fixes `#6576`) (`#6579`) (Toru Nagashima)
- 124d8a3 Docs: Pull request template (`#6568`) (Nicholas C. Zakas)
- e9a2ed9 Docs: Fix rules\id-length exceptions typos (fixes `#6397`) (`#6593`) (GramParallelo)
- a2cfa1b Fix: Make outerIIFEBody work correctly (fixes `#6585`) (`#6596`) (Nicholas C. Zakas)
- 9c451a2 Docs: Use string severity in example (`#6601`) (Kenneth Williams)
- 8308c0b Chore: remove path-is-absolute in favor of the built-in (fixes `#6598`) (`#6600`) (shinnn)
- 7a63717 Docs: Add missing pull request step (fixes `#6595`) (`#6597`) (Nicholas C. Zakas)
- de3ed84 Fix: make `no-unused-vars` ignore for-in (fixes `#2342`) (`#6126`) (Oleg Gaidarenko)
- 6ef2cbe Fix: strip Unicode BOM of config files (fixes `#6556`) (`#6580`) (Toru Nagashima)
- ee7fcfa Docs: Correct type of `outerIIFEBody` in `indent` (fixes `#6581`) (`#6584`) (alberto)
- 25fc7b7 Fix: false negative of `max-len` (fixes `#6564`) (`#6565`) (not-an-aardvark)
- f6b8452 Docs: Distinguish examples in rules under Stylistic Issues part 6 (`#6567`) (Kenneth Williams)
#### Version 3.0.0
- 66de9d8 Docs: Update installation instructions on README (`#6569`) (Nicholas C. Zakas)
- dc5b78b Breaking: Add `require-yield` rule to `eslint:recommended` (fixes `#6550`) (`#6554`) (Gyandeep Singh)
- 7988427 Fix: lib/config.js tests pass if personal config exists (fixes `#6559`) (`#6566`) (Kevin Partington)
- 4c05967 Docs: Update rule docs for new format (fixes `#5417`) (`#6551`) (Nicholas C. Zakas)
- 70da5a8 Docs: Correct link to rules page (#fixes 6553) (`#6561`) (alberto)
- e2b2030 Update: Check RegExp strings for `no-regex-spaces` (fixes `#3586`) (`#6379`) (Jackson Ray Hamilton)
- 397e51b Update: Implement outerIIFEBody for indent rule (fixes `#6259`) (`#6382`) (David Shepherd)
- 666da7c Docs: 3.0.0 migration guide (`#6521`) (Nicholas C. Zakas)
- b9bf8fb Docs: Update Governance Policy (fixes `#6452`) (`#6522`) (Nicholas C. Zakas)
- 1290657 Update: `no-unused-vars` ignores read it modifies itself (fixes `#6348`) (`#6535`) (Toru Nagashima)
- d601f6b Fix: Delete cache only when executing on files (fixes `#6459`) (`#6540`) (Kai Cataldo)
- e0d4b19 Breaking: Error thrown/printed if no config found (fixes `#5987`) (`#6538`) (Kevin Partington)
- 18663d4 Fix: false negative of `no-useless-rename` (fixes `#6502`) (`#6506`) (Toru Nagashima)
- 0a7936d Update: Add fixer for prefer-const (fixes `#6448`) (`#6486`) (Nick Heiner)
- c60341f Chore: Update index and `meta` for `"eslint:recommended"` (refs `#6403`) (`#6539`) (Mark Pedrotti)
- 73da28d Better wording for the error reported by the rule "no-else-return" `#6411` (`#6413`) (Olivier Thomann)
- e06a5b5 Update: Add fixer for arrow-parens (fixes `#4766`) (`#6501`) (madmed88)
- 5f8f3e8 Docs: Remove Box as a sponsor (`#6529`) (Nicholas C. Zakas)
- 7dfe0ad Docs: fix max-lines samples (fixes `#6516`) (`#6515`) (Dmitriy Shekhovtsov)
- fa05119 Breaking: Update eslint:recommended (fixes `#6403`) (`#6509`) (Nicholas C. Zakas)
- e96177b Docs: Add "Proposing a Rule Change" link to CONTRIBUTING.md (`#6511`) (Kevin Partington)
- bea9096 Docs: Update pull request steps (fixes `#6474`) (`#6510`) (Nicholas C. Zakas)
- 7bcf6e0 Docs: Consistent example headings & text pt3 (refs `#5446`) (`#6492`) (Guy Fraser)
- 1a328d9 Docs: Consistent example headings & text pt4 (refs `#5446`) (`#6493`) (Guy Fraser)
- ff5765e Docs: Consistent example headings & text pt2 (refs `#5446`)(`#6491`) (Guy Fraser)
- 01384fa Docs: Fixing typos (refs `#5446`)(`#6494`) (Guy Fraser)
- 4343ae8 Fix: false negative of `object-shorthand` (fixes `#6429`) (`#6434`) (Toru Nagashima)
- b7d8c7d Docs: more accurate yoda-speak (`#6497`) (Tony Lukasavage)
- 3b0ab0d Fix: add warnIgnored flag to CLIEngine.executeOnText (fixes `#6302`) (`#6305`) (Robert Levy)
- c2c6cec Docs: Mark object-shorthand as fixable. (`#6485`) (Nick Heiner)
- 5668236 Fix: Allow objectsInObjects exception when destructuring (fixes `#6469`) (`#6470`) (Adam Renklint)
- 17ac0ae Fix: `strict` rule reports a syntax error for ES2016 (fixes `#6405`) (`#6464`) (Toru Nagashima)
- 4545123 Docs: Rephrase documentation for `no-duplicate-imports` (`#6463`) (Simen Bekkhus)
- 1b133e3 Docs: improve `no-native-reassign` and specifying globals (fixes `#5358`) (`#6462`) (Toru Nagashima)
- b179373 Chore: Remove dead code in excuteOnFiles (fixes `#6467`) (`#6466`) (Andrew Hutchings)
- 18fbc4b Chore: Simplify eslint process exit code (fixes `#6368`) (`#6371`) (alberto)
- 58542e4 Breaking: Drop support for node < 4 (fixes `#4483`) (`#6401`) (alberto)
- f50657e Breaking: use default for complexity in eslint:recommended (fixes `#6021`) (`#6410`) (alberto)
- 3e690fb Fix: Exit init early if guide is chosen w/ no package.json (fixes `#6476`) (`#6478`) (Kai Cataldo)
