### PR TITLE
[Doppins] Upgrade dependency eslint-plugin-react to ~6.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-config-airbnb": "~9.0.1",
     "eslint-plugin-import": "~1.9.2",
     "eslint-plugin-jsx-a11y": "~1.5.3",
-    "eslint-plugin-react": "~6.2.1",
+    "eslint-plugin-react": "~6.2.2",
     "express": "~4.14.0",
     "extract-text-webpack-plugin": "~1.0.1",
     "file-loader": "~0.9.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-config-airbnb": "~9.0.1",
     "eslint-plugin-import": "~1.9.2",
     "eslint-plugin-jsx-a11y": "~1.5.3",
-    "eslint-plugin-react": "~6.3.0",
+    "eslint-plugin-react": "~6.4.0",
     "express": "~4.14.0",
     "extract-text-webpack-plugin": "~1.0.1",
     "file-loader": "~0.9.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-config-airbnb": "~9.0.1",
     "eslint-plugin-import": "~1.9.2",
     "eslint-plugin-jsx-a11y": "~1.5.3",
-    "eslint-plugin-react": "~6.2.2",
+    "eslint-plugin-react": "~6.3.0",
     "express": "~4.14.0",
     "extract-text-webpack-plugin": "~1.0.1",
     "file-loader": "~0.9.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-config-airbnb": "~9.0.1",
     "eslint-plugin-import": "~1.9.2",
     "eslint-plugin-jsx-a11y": "~1.5.3",
-    "eslint-plugin-react": "~5.2.2",
+    "eslint-plugin-react": "~6.1.2",
     "express": "~4.14.0",
     "extract-text-webpack-plugin": "~1.0.1",
     "file-loader": "~0.9.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-config-airbnb": "~9.0.1",
     "eslint-plugin-import": "~1.9.2",
     "eslint-plugin-jsx-a11y": "~1.5.3",
-    "eslint-plugin-react": "~6.4.0",
+    "eslint-plugin-react": "~6.4.1",
     "express": "~4.14.0",
     "extract-text-webpack-plugin": "~1.0.1",
     "file-loader": "~0.9.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-config-airbnb": "~9.0.1",
     "eslint-plugin-import": "~1.9.2",
     "eslint-plugin-jsx-a11y": "~1.5.3",
-    "eslint-plugin-react": "~6.1.2",
+    "eslint-plugin-react": "~6.2.1",
     "express": "~4.14.0",
     "extract-text-webpack-plugin": "~1.0.1",
     "file-loader": "~0.9.0",


### PR DESCRIPTION
Hi!

A new version was just released of `eslint-plugin-react`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded eslint-plugin-react from `~5.2.2` to `~6.1.2`
#### Changelog:
#### Version 6.1.2
### Fixed
- Fix nested spread handling in `no-danger-with-children` ([`#771`](`https://github.com/yannickcr/eslint-plugin-react/issues/771`) `@petersendidit`)
### Changed
- Documentation improvements
#### Version 6.1.1
### Fixed
- Fix `prop-types` on annotated components ([`#766`](`https://github.com/yannickcr/eslint-plugin-react/issues/766`))
- Fix `no-danger-with-children` spread support ([`#767`](`https://github.com/yannickcr/eslint-plugin-react/issues/767`) `@petersendidit`)
### Changed
- Documentation improvements ([`#769`](`https://github.com/yannickcr/eslint-plugin-react/pull/769`) `@daltones`)
#### Version 6.1.0
### Added
- Add `React.PureComponent` support ([`#737`](`https://github.com/yannickcr/eslint-plugin-react/issues/737`))
- Add `forbid-component-props` rule ([`#314`](`https://github.com/yannickcr/eslint-plugin-react/pull/314`) `@lencioni`)
- Add `no-danger-with-children` rule ([`#710`](`https://github.com/yannickcr/eslint-plugin-react/issues/710`) `@petersendidit`)
- Add pragma for `createClass` factory method ([`#725`](`https://github.com/yannickcr/eslint-plugin-react/pull/725`) `@zurawiki`)
### Fixed
- Fix Node.js 0.10 support ([`#746`](`https://github.com/yannickcr/eslint-plugin-react/issues/746`))
- Fix `prop-types` on annotated components ([`#729`](`https://github.com/yannickcr/eslint-plugin-react/issues/729`))
- Fix `require-optimization` test for function declaration ([`#744`](`https://github.com/yannickcr/eslint-plugin-react/pull/744`) `@Tom910`)
- Fix `jsx-uses-var` to handle nested object properties ([`#761`](`https://github.com/yannickcr/eslint-plugin-react/pull/761`) `@yayalice`)
- Fix rules metadata
### Changed
- Update dependencies
- Documentation improvements ([`#759`](`https://github.com/yannickcr/eslint-plugin-react/pull/759`) `@embrown`, [`#703`](`https://github.com/yannickcr/eslint-plugin-react/pull/703`) [`#753`](`https://github.com/yannickcr/eslint-plugin-react/pull/753`) `@lencioni`, [`#739`](`https://github.com/yannickcr/eslint-plugin-react/issues/739`) `@ljharb`, [`#731`](`https://github.com/yannickcr/eslint-plugin-react/pull/731`) `@wKich`, [`#745`](`https://github.com/yannickcr/eslint-plugin-react/pull/745`) `@petersendidit`, [`#659`](`https://github.com/yannickcr/eslint-plugin-react/pull/659`) `@dguo`)
#### Version 6.0.0
### Added
- Add an `all` sharable configuration with all rules enabled ([`#674`](`https://github.com/yannickcr/eslint-plugin-react/issues/674`) `@pfhayes`)
- Add `no-find-dom-node` rule ([`#678`](`https://github.com/yannickcr/eslint-plugin-react/issues/678`))
- Add `shorthandFirst` option to `jsx-sort-props` ([`#391`](`https://github.com/yannickcr/eslint-plugin-react/issues/391`) `@mathieumg`)
- Add `allowDecorators` option to `require-optimization` ([`#669`](`https://github.com/yannickcr/eslint-plugin-react/pull/669`) `@Tom910`)
### Breaking
- Deprecate `require-extension` rule, use the eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import) [`extensions` (`https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md`) rule instead. `require-extension` still works but will trigger a warning
- Enable `allow-in-func` mode by default in `no-did-mount-set-state` and `no-did-update-set-state` rules ([`#702`](`https://github.com/yannickcr/eslint-plugin-react/pull/702`) `@lencioni`)
- Enable html tags check by default in `self-closing-comp`
- Remove `pragma` option from `jsx-uses-react`, use the [shared settings](README.md#configuration) to specify a custom pragma ([`#700`](`https://github.com/yannickcr/eslint-plugin-react/pull/700`) `@lencioni`)
- Remove `react` option from `no-deprecated` rule, use the [shared settings](README.md#configuration) to specify the React version ([`#700`](`https://github.com/yannickcr/eslint-plugin-react/pull/700`) `@lencioni`)
- Add `require-render-return` rule to recommended rules
- Remove `no-danger` from recommended rules ([`#636`](`https://github.com/yannickcr/eslint-plugin-react/pull/636`) `@mjackson`)
- Remove `no-did-mount-set-state` and `no-did-update-set-state` from recommended rules ([`#596`](`https://github.com/yannickcr/eslint-plugin-react/issues/596`))
- Remove deprecated `jsx-sort-prop-types` rule, use `sort-prop-types` instead ([`#549`](`https://github.com/yannickcr/eslint-plugin-react/issues/549`) `@lencioni`)
- Rename `no-comment-textnodes` to `jsx-no-comment-textnodes`. `no-comment-textnodes` still works but will trigger a warning ([`#668`](`https://github.com/yannickcr/eslint-plugin-react/issues/668`) `@lencioni`)
- Rename `wrap-multilines` to `jsx-wrap-multilines`. `wrap-multilines` still works but will trigger a warning ([`#668`](`https://github.com/yannickcr/eslint-plugin-react/issues/668`) `@lencioni`)
- Add ESLint as peerDependency ([`#657`](`https://github.com/yannickcr/eslint-plugin-react/pull/657`) `@jokeyrhyme`)
- Add Node.js 0.10 as minimum required version ([`#657`](`https://github.com/yannickcr/eslint-plugin-react/pull/657`) `@jokeyrhyme`)
### Fixed
- Fix `jsx-handler-names` incorrectly flagging `only` ([`#571`](`https://github.com/yannickcr/eslint-plugin-react/issues/571`) `@lencioni`)
- Fix spread props cash in `jsx-no-target-blank` ([`#679`](`https://github.com/yannickcr/eslint-plugin-react/pull/679`) `@randycoulman`)
- Fix `require-optimization` warning on stateless components ([`#687`](`https://github.com/yannickcr/eslint-plugin-react/issues/687`))
- Fix `jsx-uses-vars` that incorrectly marked some variables as used ([`#694`](`https://github.com/yannickcr/eslint-plugin-react/issues/694`) `@lencioni`)
- Fix `no-unknown-property` check on SVG attributes ([`#718`](`https://github.com/yannickcr/eslint-plugin-react/issues/718`))
- Fix `jsx-no-bind` reporting errors on render functions that don't return JSX ([`#663`](`https://github.com/yannickcr/eslint-plugin-react/issues/663`) `@petersendidit`)
- Fix `jsx-closing-bracket-location` autofix when `location` is set to `props-aligned` ([`#684`](`https://github.com/yannickcr/eslint-plugin-react/pull/684`) `@pfhayes`)
- Fix `prop-types` for destructured arguments being assigned to the parent stateless component in some cases ([`#698`](`https://github.com/yannickcr/eslint-plugin-react/issues/698`))
- Fix `prop-types` for JSX return being assigned to the parent function in some cases ([`#504`](`https://github.com/yannickcr/eslint-plugin-react/issues/504`))
- Fix `jsx-curly-spacing` for reporting on JSX content by mistake ([`#671`](`https://github.com/yannickcr/eslint-plugin-react/issues/671`))
- Fix `prop-types` crash when accessing constructor on props ([`#654`](`https://github.com/yannickcr/eslint-plugin-react/issues/654`))
- Fix `jsx-filename-extension` to not check filenames on text input ([`#662`](`https://github.com/yannickcr/eslint-plugin-react/issues/662`) `@ljharb`)
- Fix `jsx-no-comment-textnodes` incorrectly catching urls ([`#664`](`https://github.com/yannickcr/eslint-plugin-react/issues/664`) `@petersendidit`)
### Changed
- Only report `jsx-filename-extension` warning once per file ([`#660`](`https://github.com/yannickcr/eslint-plugin-react/pull/660`) `@mathieumg`)
- Update SVG and DOM attribute list for `no-unknown-property`
- Update rules to use the new ESLint rule format ([`#661`](`https://github.com/yannickcr/eslint-plugin-react/issues/661`) `@petersendidit`)
- Update dependencies
- Documentation improvements ([`#724`](`https://github.com/yannickcr/eslint-plugin-react/pull/724`) `@lencioni`)
- Update Travis CI and AppVeyor CI configurations (`@ljharb`)
#### Version 6.0.0
### Fixed
- Fix `jsx-handler-names` incorrectly flagging `only` ([`#571`](`https://github.com/yannickcr/eslint-plugin-react/issues/571`) `@lencioni`)
- Fix `wrap-multilines` rule ([`#728`](`https://github.com/yannickcr/eslint-plugin-react/pull/728`) `@akozhemiakin`)
#### Version 6.0.0
### Fixed
- Fix spread props crash in `jsx-no-target-blank` ([`#679`](`https://github.com/yannickcr/eslint-plugin-react/pull/679`) `@randycoulman`)
- Fix `require-optimization` warning on stateless components ([`#687`](`https://github.com/yannickcr/eslint-plugin-react/issues/687`))
- Fix `jsx-uses-vars` that incorrectly marked some variables as used ([`#694`](`https://github.com/yannickcr/eslint-plugin-react/issues/694`) `@lencioni`)
- Fix `no-unknown-property` check on SVG attributes ([`#718`](`https://github.com/yannickcr/eslint-plugin-react/issues/718`))
- Fix `all` config to not include deprecated rules ([`#723`](`https://github.com/yannickcr/eslint-plugin-react/pull/723`) `@pfhayes`)
### Breaking
- Deprecate `require-extension rule`, use the eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import) [`extensions` (`https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md`) rule instead
- Enable `allow-in-func` mode by default in `no-did-mount-set-state` and `no-did-update-set-state` rules ([`#702`](`https://github.com/yannickcr/eslint-plugin-react/pull/702`) `@lencioni`)
- Enable html tags check by default in `self-closing-comp`
- Remove `pragma` option from `jsx-uses-react`, use the [shared settings](README.md#configuration) to specify a custom pragma ([`#700`](`https://github.com/yannickcr/eslint-plugin-react/pull/700`) `@lencioni`)
- Remove `react` option from `no-deprecated` rule, use the [shared settings](README.md#configuration) to specify the React version ([`#700`](`https://github.com/yannickcr/eslint-plugin-react/pull/700`) `@lencioni`)
- Remove `no-danger` from recommended rules ([`#636`](`https://github.com/yannickcr/eslint-plugin-react/pull/636`) `@mjackson`)
- Remove `no-did-mount-set-state` and no-did-update-set-state from recommended rules ([`#596`](`https://github.com/yannickcr/eslint-plugin-react/issues/596`))
- Add `require-render-return` rule to recommended rules
### Changed
- Update SVG and DOM attribute list for `no-unknown-property`
- Update rules to use the new ESLint rule format ([`#661`](`https://github.com/yannickcr/eslint-plugin-react/issues/661`) `@petersendidit`)
- Documentation improvements ([`#724`](`https://github.com/yannickcr/eslint-plugin-react/pull/724`) `@lencioni`)
#### Version 6.0.0
### Added
- Add an `all` sharable configuration with all rules enabled ([`#674`](`https://github.com/yannickcr/eslint-plugin-react/issues/674`) `@pfhayes`)
- Add `no-find-dom-node` rule ([`#678`](`https://github.com/yannickcr/eslint-plugin-react/issues/678`))
- Add `shorthandFirst` option to `jsx-sort-props` ([`#391`](`https://github.com/yannickcr/eslint-plugin-react/issues/391`) `@mathieumg`)
- Add `allowDecorators` option to `require-optimization` ([`#669`](`https://github.com/yannickcr/eslint-plugin-react/pull/669`) `@Tom910`)
### Fixed
- Fix `jsx-no-bind` reporting errors on render functions that don't return JSX ([`#663`](`https://github.com/yannickcr/eslint-plugin-react/issues/663`) `@petersendidit`)
- Fix `jsx-closing-bracket-location` autofix when `location` is set to `props-aligned` ([`#684`](`https://github.com/yannickcr/eslint-plugin-react/pull/684`) `@pfhayes`)
- Fix `prop-types` for destructured arguments being assigned to the parent stateless component in some cases ([`#698`](`https://github.com/yannickcr/eslint-plugin-react/issues/698`))
- Fix `prop-types` for JSX return being assigned to the parent function in some cases ([`#504`](`https://github.com/yannickcr/eslint-plugin-react/issues/504`))
- Fix `jsx-curly-spacing` for reporting on JSX content by mistake ([`#671`](`https://github.com/yannickcr/eslint-plugin-react/issues/671`))
### Breaking
- Remove deprecated `jsx-sort-prop-types` rule, use `sort-prop-types` instead ([`#549`](`https://github.com/yannickcr/eslint-plugin-react/issues/549`) `@lencioni`)
- Rename `jsx-no-comment-textnodes` to `no-comment-textnodes`. `jsx-no-comment-textnodes` still works but will trigger a warning ([`#668`](`https://github.com/yannickcr/eslint-plugin-react/issues/668`) `@lencioni`)
- Rename `jsx-require-extension` to `require-extension`. `jsx-require-extension` still works but will trigger a warning ([`#668`](`https://github.com/yannickcr/eslint-plugin-react/issues/668`) `@lencioni`)
- Rename `jsx-wrap-multilines` to `wrap-multilines`. `jsx-wrap-multilines` still works but will trigger a warning ([`#668`](`https://github.com/yannickcr/eslint-plugin-react/issues/668`) `@lencioni`)
### Changed
- Update dependencies
- Only report `jsx-filename-extension` warning once per file ([`#660`](`https://github.com/yannickcr/eslint-plugin-react/pull/660`) `@mathieumg`)
#### Version 6.0.0
### Fixed
- Fix `prop-types` crash when accessing constructor on props ([`#654`](`https://github.com/yannickcr/eslint-plugin-react/issues/654`))
- Fix `jsx-filename-extension` to not check filenames on text input ([`#662`](`https://github.com/yannickcr/eslint-plugin-react/issues/662`) `@ljharb`)
- Fix `no-comment-textnodes` incorrectly catching urls ([`#664`](`https://github.com/yannickcr/eslint-plugin-react/issues/664`) `@petersendidit`)
### Breaking
- Add ESLint as peerDependency ([`#657`](`https://github.com/yannickcr/eslint-plugin-react/pull/657`) `@jokeyrhyme`)
- Add Node.js 0.10 as minimum required version ([`#657`](`https://github.com/yannickcr/eslint-plugin-react/pull/657`) `@jokeyrhyme`)
### Changed
- Update dependencies
- Update Travis CI and AppVeyor CI configurations (`@ljharb`)
