### PR TITLE
[Doppins] Upgrade dependency webdriverio to ~4.2.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "wdio-junit-reporter": "~0.1.0",
     "wdio-sauce-service": "~0.2.2",
     "wdio-selenium-standalone-service": "~0.0.5",
-    "webdriverio": "~4.2.7",
+    "webdriverio": "~4.2.8",
     "webpack": "~1.13.1",
     "webpack-dev-middleware": "~1.6.1",
     "webpack-hot-middleware": "~2.12.0"

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "wdio-junit-reporter": "~0.1.0",
     "wdio-sauce-service": "~0.2.2",
     "wdio-selenium-standalone-service": "~0.0.5",
-    "webdriverio": "~4.2.15",
+    "webdriverio": "~4.2.16",
     "webpack": "~1.13.1",
     "webpack-dev-middleware": "~1.6.1",
     "webpack-hot-middleware": "~2.12.0"

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "wdio-junit-reporter": "~0.1.0",
     "wdio-sauce-service": "~0.2.2",
     "wdio-selenium-standalone-service": "~0.0.5",
-    "webdriverio": "~4.2.13",
+    "webdriverio": "~4.2.14",
     "webpack": "~1.13.1",
     "webpack-dev-middleware": "~1.6.1",
     "webpack-hot-middleware": "~2.12.0"

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "wdio-junit-reporter": "~0.1.0",
     "wdio-sauce-service": "~0.2.2",
     "wdio-selenium-standalone-service": "~0.0.5",
-    "webdriverio": "~4.2.14",
+    "webdriverio": "~4.2.15",
     "webpack": "~1.13.1",
     "webpack-dev-middleware": "~1.6.1",
     "webpack-hot-middleware": "~2.12.0"

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "wdio-junit-reporter": "~0.1.0",
     "wdio-sauce-service": "~0.2.2",
     "wdio-selenium-standalone-service": "~0.0.5",
-    "webdriverio": "~4.2.5",
+    "webdriverio": "~4.2.7",
     "webpack": "~1.13.1",
     "webpack-dev-middleware": "~1.6.1",
     "webpack-hot-middleware": "~2.12.0"

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "wdio-junit-reporter": "~0.1.0",
     "wdio-sauce-service": "~0.2.2",
     "wdio-selenium-standalone-service": "~0.0.5",
-    "webdriverio": "~4.2.12",
+    "webdriverio": "~4.2.13",
     "webpack": "~1.13.1",
     "webpack-dev-middleware": "~1.6.1",
     "webpack-hot-middleware": "~2.12.0"

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "wdio-junit-reporter": "~0.1.0",
     "wdio-sauce-service": "~0.2.2",
     "wdio-selenium-standalone-service": "~0.0.5",
-    "webdriverio": "~4.2.8",
+    "webdriverio": "~4.2.12",
     "webpack": "~1.13.1",
     "webpack-dev-middleware": "~1.6.1",
     "webpack-hot-middleware": "~2.12.0"

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "wdio-junit-reporter": "~0.1.0",
     "wdio-sauce-service": "~0.2.2",
     "wdio-selenium-standalone-service": "~0.0.5",
-    "webdriverio": "~4.1.1",
+    "webdriverio": "~4.2.5",
     "webpack": "~1.13.1",
     "webpack-dev-middleware": "~1.6.1",
     "webpack-hot-middleware": "~2.12.0"


### PR DESCRIPTION
Hi!

A new version was just released of `webdriverio`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded webdriverio from `~4.1.1` to `~4.2.5`
