### PR TITLE
[Doppins] Upgrade dependency css-loader to ~0.25.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "chai": "~3.5.0",
     "chai-as-promised": "~5.3.0",
     "copy-webpack-plugin": "~3.0.1",
-    "css-loader": "~0.23.1",
+    "css-loader": "~0.24.0",
     "cucumber": "~0.10.2",
     "eslint": "~2.13.1",
     "eslint-config-airbnb": "~9.0.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "chai": "~3.5.0",
     "chai-as-promised": "~5.3.0",
     "copy-webpack-plugin": "~3.0.1",
-    "css-loader": "~0.24.0",
+    "css-loader": "~0.25.0",
     "cucumber": "~0.10.2",
     "eslint": "~2.13.1",
     "eslint-config-airbnb": "~9.0.1",


### PR DESCRIPTION
Hi!

A new version was just released of `css-loader`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded css-loader from `~0.23.1` to `~0.24.0`
