### PR TITLE
[Doppins] Upgrade dependency moment to 2.15.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "draft-js": "0.7.0",
     "json-loader": "^0.5.4",
     "lodash": "4.13.1",
-    "moment": "2.15.0",
+    "moment": "2.15.1",
     "normalize.css": "4.2.0",
     "raven-js": "3.3.0",
     "react": "15.1.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "draft-js": "0.7.0",
     "json-loader": "^0.5.4",
     "lodash": "4.13.1",
-    "moment": "2.13.0",
+    "moment": "2.15.0",
     "normalize.css": "4.2.0",
     "raven-js": "3.3.0",
     "react": "15.1.0",


### PR DESCRIPTION
Hi!

A new version was just released of `moment`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded moment from `2.13.0` to `2.15.0`
