### PR TITLE
[Doppins] Upgrade dependency redux to 3.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "react-notification-system": "0.2.7",
     "react-redux": "4.4.5",
     "react-router": "2.5.1",
-    "redux": "3.5.2",
+    "redux": "3.6.0",
     "redux-form": "5.3.2",
     "redux-thunk": "2.1.0",
     "semantic-ui-css": "2.2.1"


### PR DESCRIPTION
Hi!

A new version was just released of `redux`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded redux from `3.5.2` to `3.6.0`
#### Changelog:
#### Version 3.6.0
### Hey, it's been a while!

How's everyone doing? Enjoying your summer (or winter for the Southern Hemisphere folks)?

This is a bugfix release for Redux. We're working towards a 4.0 with more substantial changes. Please see `#1342` to pitch in!

Dan also ported all the examples (except the universal one) in `#1883` to use the excellent [Create React App](https://github.com/facebookincubator/create-react-app). This means the changes in `#1800` have been lost. If you'd like to help out, we would love PRs on the examples to modernize and clean them up. 
### Changes
- Updated symbol-observable to 1.0.2 (`#1663` and `#1877`) 
- Added a Redux logo (`#1671`)
- Replace es3ify with Babel ES3 transforms (`#1688`)
- Run tests on Node 6 (`#1673`)
- Optimize one function case in compose (`#1701`)
- Check ES3 syntax compatibility (`#1720`)
- TypeScript: preloadedState is optional (`#1806`)
- Add a warning for undefined properties passed to combineReducers (`#1789`)
- Add module entry point for webpack 2 (`#1871`)
- TypeScript: Improve typings for compose function (`#1868`)
