### PR TITLE
[Doppins] Upgrade dependency redux-form to 6.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "react-redux": "4.4.5",
     "react-router": "2.5.1",
     "redux": "3.5.2",
-    "redux-form": "6.0.5",
+    "redux-form": "6.1.0",
     "redux-thunk": "2.1.0",
     "semantic-ui-css": "2.2.1"
   }

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "react-redux": "4.4.5",
     "react-router": "2.5.1",
     "redux": "3.5.2",
-    "redux-form": "6.0.3",
+    "redux-form": "6.0.4",
     "redux-thunk": "2.1.0",
     "semantic-ui-css": "2.2.1"
   }

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "react-redux": "4.4.5",
     "react-router": "2.5.1",
     "redux": "3.5.2",
-    "redux-form": "5.3.2",
+    "redux-form": "6.0.2",
     "redux-thunk": "2.1.0",
     "semantic-ui-css": "2.2.1"
   }

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "react-redux": "4.4.5",
     "react-router": "2.5.1",
     "redux": "3.5.2",
-    "redux-form": "6.0.4",
+    "redux-form": "6.0.5",
     "redux-thunk": "2.1.0",
     "semantic-ui-css": "2.2.1"
   }

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "react-redux": "4.4.5",
     "react-router": "2.5.1",
     "redux": "3.5.2",
-    "redux-form": "6.0.2",
+    "redux-form": "6.0.3",
     "redux-thunk": "2.1.0",
     "semantic-ui-css": "2.2.1"
   }


### PR DESCRIPTION
Hi!

A new version was just released of `redux-form`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded redux-form from `5.3.2` to `6.0.2`
#### Changelog:
#### Version 6.0.2
- Bug fix involving submission error not being cleared. `#1654` `#1641` Thanks, `@ortex`!
- Fixed issue with the `jsnext:main` build. `#1671` `#1637` Thanks, `@NotWoods`!
- Added `props` to `handleSubmit` call. `#1639` `#1629` Thanks, `@olistic`!
- Up to 5x performance gains when reading deep objects. `#1667` Thanks, `@smirea`!
- A lot of documentation clean-up by `@kevinzwh`.

Thanks for all your help, guys.
#### Version 6.0.1
# 🎉 🎉 IT'S HERE!!! 🎉 🎉

Thank you _SO MUCH_ to all of you who have helped test and improve `v6` over the past four months.

(It's called `v6.0.1` because of a previous mistake with npm...oops.)
## [`v5` → `v6` Migration Guide](http://redux-form.com/6.0.1/docs/MigrationGuide.md/)
## Changes since `v6.0.0-rc.5` (`https://github.com/erikras/redux-form/releases/tag/v6.0.0-rc.5`)
### Bug Fixes
- Added `dispatch` to props for `Field`. `#1569` `#1567`
- Put back bound `blur` and `change` actions in form props. `#1588` `#1579`
- Fixed how custom props were being given to `Fields` component. `#1589` `#1583`
- Fixed bug where `FieldArray` was rerendering on every value change. `#1590` `#1578`
- Fixed bug involving pushing `undefined` into an array. `#1591` `#1574` 
- Fixed bug where `FieldArray` would not rerender on add/remove. `#1594` `#1592`
- Passed through `initialValues` prop to form component. `#1598` `#1570` 
- Fixed bug where form-wide `_error` wasn't flipping `valid` and `invalid` flags. `#1606` `#1603` 
### Features
- Implemented "autofill" feature from `v5`. `#1620` `#1614`
- All dependencies are up to date! 📆 👯
### Breaking Changes
- Killed off the `defaultValue` prop to `Field`, at was causing confusion. If you have a field that requires a type other than string, you should provide the value via `initialValues`. `#1593` `#1341` 
#### Version 5.3.3
- `props` is now passed to `handleSubmit()`. `#1548` `#1546`
- Fixed rare `TypeError` during normalization. `#1359` `#1358`

In all likelihood, this will be the last release of `redux-form v5.x`. Pull requests will still be evaluated and potentially merged for additional releases. Please make such PRs to the `v5` branch (`https://github.com/erikras/redux-form/tree/v5`).
#### Version 6.0.0-rc.5
### Bug Fixes
- Updated exported `propTypes`. `#1447` 
- Fixed a bug with array splicing. `#1492` `#1490` Thanks, `@clayne11`!
- Fixed a bug with field unregistering. `#1486` `#1460`
- Fixed a bug with reinitializing on remounting. `#1556` `#1503` 
- Allowed sync validation to set a form wide `_error` like async and submit validation could. `#1560` `#1533` `#1328`
- Fixed a bug where fields would not amend their registration when their `name` prop changed. `#1561` `#1528`
### Features
- Added a [`keepDirtyOnReinitialize` config parameter](http://redux-form.com/6.0.0-rc.5/docs/api/ReduxForm.md/#-keepdirtyonreinitialize-boolean-optional-) that will allow the `initialValues` to change without overwriting dirty fields. This is useful if you are continually saving the data as the user fills out the form. See `#1465` for more details. Thanks, `@hathawsh`!
- `blurredField` now passed to [`asyncValidate`](http://redux-form.com/6.0.0-rc.5/docs/api/ReduxForm.md/#-asyncvalidate-values-object-dispatch-function-props-object-blurredfield-string-promise-undefined-errors-object-optional-). `#1539` `#817` `#980` `#1511` Thanks, `@KaboomFox`!
- Allowed fields to have a `_error` assigned to them. `#1508` `#1107` Thanks, `@clayne11`!
- Fields now get a [`meta.submitting`](http://redux-form.com/6.0.0-rc.5/docs/api/Field.md/#-meta-submitting-boolean-) flag. `#1509` `#1122` Thanks, `@clayne11`!
- Added a [`pure` config parameter](http://redux-form.com/6.0.0-rc.5/docs/api/ReduxForm.md/#-pure-boolean-optional-) that can short circuit `shouldComponentUpdate()`. `#1449` Thanks, `@edvinerikson`!
- Added 🎉 [`Fields` component](http://redux-form.com/6.0.0-rc.5/docs/api/Fields.md/)  🎉  that allows you to connect to multiple fields at a time. This was the last major piece of functionality to allow you to do in `v6` what you could do in `v5`. `#1554` 
## Why no release yet?

There is one other breaking change that I want to consider squeezing into `v6.0.0`.
### 👉 Please go here and vote on your preference (`https://github.com/erikras/redux-form/issues/1562`). 👈
#### Version 6.0.0-rc.4

I really wanted to release `v6.0.0` in July, especially since Redux Form's birthday was July 31, one year after the initial commit on July 31, 2015. 🎂🎉

However, some new features and breaking changes appeared, and I'd feel more comfortable if they were released for a week as an RC to ensure a lack of bugs before pulling the trigger on the release.
## Bug Fixes
- Fixed drag and drop bug in IE. `#1373` `#1088` 
- Removed `Array.findIndex()` polyfill. `#1412` `#1326` (IE again 😡)
- Fixed quirky bug when reading values from events. `#1369` `#1355` 
- Added missing array action creators to the `propTypes` list.
## Features
- Added `parse` and `format` props to `Field`, giving much more control to how values are transformed when transported between the Redux Store and the input. `#1412` This was always a feature that had been planned for `v6`. See: [`Field`](http://redux-form.com/6.0.0-rc.4/docs/api/Field.md/#props-you-can-pass-to-field-) and [Value Lifecycle](http://redux-form.com/6.0.0-rc.4/docs/ValueLifecycle.md/)
- Added a set of selectors for reading form state from any `connect()`ed component. See: [Selectors](http://redux-form.com/6.0.0-rc.4/docs/api/Selectors.md/)
## ⚠ Breaking Change ⚠

It came to my attention that my initial attempt at resolving the React `v15.2.0` prop warning problem in `v6.0.0-rc.2` (`https://github.com/erikras/redux-form/releases/tag/v6.0.0-rc.2`) was horribly flawed. A poll was conducted on `#1425`, and a _relatively_ clear winner (not one of my ideas - 🍻 `@kristian-puccio`) was chosen. Please read that ticket for all the details, but I will summarize here.

The `Field` component is in charge of passing three types of props to its component:
- `input` props - Props meant specifically for the input element, like `value`, `onBlur`, etc.
- `meta` props - Metadata about your field that Redux Form is providing, like `error`, `dirty`, etc.
- `custom` props - Any other props that you have given to `Field`

The solution wrongheadedly decided in `v6.0.0-rc.2` was to pass them to the component in the following structure:

``` js
{
  input: {
    ...input,
    ...custom,
  },
  ...meta
}
```

...such that any additional props that you passed would be lumped in with the ones that `redux-form` provides for your input. This was dumb.

Now, they are passed as such:

``` js
{
  input,
  meta,
  ...custom
}
```

The two sets of _special_ props that `redux-form` provides you are encapsulated in `input` and `meta` objects, and all the additional props that you pass will be in the root. So a typical `renderField` component might look a little something like this, with ES6 inline parameter destructuring:

``` jsx
const renderField = ({ input, label, type, meta: { touched, error } }) => (
  <div>
    <label>{label}</label>
    <div>
      <input {...input} placeholder={label} type={type}/>
      {touched && error && <span>{error}</span>}
    </div>
  </div>
)
...
<Field name="username" type="text" component={renderField} label="Username"/>
```
## Conclusion

I do not foresee any future breaking changes between now and release. As always, feedback is extremely welcome.
#### Version 6.0.0-rc.3
- Fixed pretty big sync validation bug. `#1274` `#1279` `#1282` `#1284`  

It got fixed by placing the sync validation errors into the Redux store. This is something people have been asking for since `#45`, but I have resisted. It's going to make things a lot easier. Read more about it on `#1292`.
#### Version 6.0.0-rc.2
- Fixed bug involving validation and promise rejection. `#1266` 
## Breaking Change

Apologies for a major breaking change this close to release, but React just sprung this on us.

In React 15.2.0, you will get a warning (`https://github.com/erikras/redux-form/issues/1249`) in the console if you pass props to a DOM element that are not known by that element. For example, you cannot pass a `pristine` prop to an `<input>` component. If you are familiar with `redux-form`, you will understand that this is a problem for the "destructure all the props out into the `<input>`" paradigm that `redux-form` uses. As such, the props that the input needs, `value`, `onChange`, `onBlur`, etc., have been placed in a separate `input` structure in the props that `Field` gives to your component. The change is very small, but your code will break if you do not make it. Everywhere where you were destructuring `{...field}` into an input, you will need to destructure `{...field.input}` instead.

``` js
const renderField = field => (
  <div>
    <input {...field.input}/>
                 // ^^^^^^------------------ THAT is all you have to add. 👍
    {field.touched && field.error && <span>{field.error}</span>}
  </div>
)
```

You may read more about this on `#1249` and the other issues and gists linked therein.
#### `onUpdate` prop removed

`onUpdate` was added in this library's infancy to make it work better "out of the box" with [Belle](http://nikgraf.github.io/belle/). But since the input props got moved in this version, it no longer will work "out of the box" with any UI widget library, so it was removed for clarity. It was only ever an alias for `onChange`.
#### Version 6.0.0-rc.1
- Added [`normalize`](http://redux-form.com/6.0.0-rc.1/docs/api/Field.md/#-normalize-value-previousvalue-allvalues-previousallvalues-nextvalue-optional-) prop to `Field`, providing normalization functionality similar to that of `v5`. `#1115` 
- Automatic number parsing for `<input type="number"/>` inputs. `#1136` 
- Removed use of lodash `partial`. `#1117` 
- Fixed bug `#1024`, where field would not rerender when its sync error changed. `#1120` 
- Added `enableReinitialize` config parameter to address the perennial "do we reinitialize when `initialValues` changes, or not?" question. `#1121` `#832` `#1084` 
- Fixed bug in the `plugin` API. `#1127` 
- Fixed rerendering issue in `componentShouldUpdate`. `#1171` 
- Added missing `move()` and `removeAll()` functions for `FieldArray` usage. `#1198` 
- RIP `returnRejectedSubmitPromise`. A rejected submission will _always_ return a rejected promise. `#1203` 
- Fixed "no `registeredFields`" bug `#1124` `#1254` `#1231` 
- Added `onSubmitSuccess` and `onSubmitFail` functionality from `v5`. `#1257`
- Added `propNamespace`, a rarely used feature of `v5`. `#1258`

We've gone up to RC on this release because the API seems very stable and the code is production ready. We're going to allow another week or two for bugs to be discovered before release.

Any pending enhancements – and there are [some good ones](https://github.com/erikras/redux-form/issues?q=is%3Aopen+is%3Aissue+milestone%3Anext-6.0.0+label%3Aenhancement)! – should not be breaking changes, and may be released as feature updates.
#### Version 6.0.0-alpha.15

**We're getting close now!** I'm keeping this as `alpha` still, because it's not yet a feature-complete upgrade from `v5`. But `redux-form` `v6` is _very_ stable and solid. Personally, I would use it in production, but because it's not "done" yet, I must mark it as "pre-release".

---
- Prevented `RESET` and `INITIALIZE` from destroying registered fields. `#1040` 
- Added `removeAll()` and `move()` to array actions. `#822` `#1095` 
- Workaround for splice error `#1082` 
- `number` and `range` inputs will now have numeric values. `#1100` Possible **breaking change**?
- Allowed you to pass additional props to `Field` and `FieldArray` via a `props` prop. Apparently this is useful for TypeScript people. `#1078` `#1066`
- Provided reference to wrapped form component. Useful for testing. `#1101` `#1081` 
- Fixed bug where all fields weren't being marked `touched` on submit. `#1102` `#1043` 
- Implemented `plugin()` feature from `v5`. Works pretty much the same, except that the `redux-form` state shape has changed. Refer to the [Migration Guide](http://redux-form.com/6.0.0-alpha.15/docs/MigrationGuide.md/#listening-to-other-actions).
- Better [Instance API](http://redux-form.com/6.0.0-alpha.15/docs/api/ReduxForm.md/#instance-api) docs
### New Example
- Added [example for using `redux-form` with `react-widgets`](http://redux-form.com/6.0.0-alpha.15/examples/react-widgets/). It's pretty trivial.
### Breaking Change
- After a pseudo-democratic vote (`https://github.com/erikras/redux-form/issues/1063`), it was decided that the pseudo-array object that `FieldArray` generates should be in a separate prop, called `fields`.

`v6.0.0-alpha.14`

``` js
const renderWidgets = fields =>
  fields.map(field => <Field name={field} component="input"/>)
...
<FieldArray name="widgets" component={renderWidgets}/>
```

`v6.0.0-alpha.15`

``` js
const renderWidgets = props =>
  props.fields.map(field => <Field name={field} component="input"/>)
...
<FieldArray name="widgets" component={renderWidgets}/>
```
#### Version 6.0.0-alpha.14
- `Field` and `FieldArray` now have instance-level `dirty`, `pristine`, and `value` properties. `#988` `#993` 
- `form` value given to `reduxForm()` now available as a prop to the decorated component. `#1007` 
- Minor fix for race conditions when blurring and focussing. `#1004` 
- Fixed `handleSubmit` bug when the submit button is clicked rapidly. `#986` 
- Added missing action creator exports. `#1013` 
- Fixed bug with array field initialization and blurring. `#1023` 

We've got some 😃 news and some 😢 news. Let's start off with the latter...
## 😢 Breaking Change

Well, not so much breaking, as embracing a problem (`#961`) that _seemed_ broken before. The way that the Migration Guide recommended `<Field>` be used was flawed. There is a new rule:

---
#### You may not inline "fat arrow components" inside your form's `render()` method.

---

Let's look at what that means:
##### WRONG: 😢 👎

``` js
class MyForm extends Component {
  render() {
    const { handleSubmit } = this.props
    return (
      <form onSubmit={handleSubmit}>
        <Field name="username" component={props => // <----- CANNOT DO THIS
          <div>
            <input type="text" {...props}/>
            {props.touched && props.error && <span>{props.error}</span>}
          </div>
        }/>
      </form>
    )
  }
}
```
##### RIGHT: 😄 👍

``` js
// define "fat arrow component" outside of render()
const renderInput = props =>
  <div>
    <input type="text" {...props}/>
    {props.touched && props.error && <span>{props.error}</span>}
  </div>

class MyForm extends Component {
  render() {
    const { handleSubmit } = this.props
    return (
      <form onSubmit={handleSubmit}>
        <Field name="username" component={renderInput}/> // <-- refer to component
      </form>
    )
  }
}
```
#### That sucks! Why?

The reason is that defining a fat arrow component inside render _creates a new component_ on every form render, which causes each `Field` to rerender (because the `component` prop is `!==`). If you don't care that much about performance, and you are using a custom input widget, you might still be able to get away with it, but if you are using an `<input>` component, that input will lose its focus whenever the form is rerendered.

It's not that bad. Take a look at the [Examples](http://redux-form.com/6.0.0-alpha.14/examples/) and see if you don't agree that the code is cleaner this way.
## 😃 Adapter API

As a side effect of the breaking change above, an "adapter" API was developed, as a way to provide a shorthand for referring to commonly used input render routines. Check out the new [Adapter Example](http://redux-form.com/6.0.0-alpha.14/examples/adapter/).
#### Version 6.0.0-alpha.13
- Fixed annoying rerendering bug that was causing form input focus to be lost. `#961` 
- Important performance improvements using `react-redux`'s memoization API from `@ooflorent` with `#964` 
#### Version 6.0.0-alpha.11
- Allowed object-level general (`_error`) errors for array values. `#965` 
- Created [`formValueSelector()`](http://redux-form.com/6.0.0-alpha.11/docs/api/FormValueSelector.md/) API to provide convenience in selecting form values. `#841` `#945` `#967` `#972` 
- Created [Selecting Form Values](http://redux-form.com/6.0.0-alpha.11/examples/selectingFormValues/) example to demonstrate the [`formValueSelector()`](http://redux-form.com/6.0.0-alpha.11/docs/api/FormValueSelector.md/) API.
#### Version 6.0.0-alpha.10

No difference from `v6.0.0-alpha.9`. `@erikras` just made a mistake with `npm`. 🙈 

Nothing to see here. 👮 
#### Version 6.0.0-alpha.9
- Now treats `null` the same as `undefined` when defaulting to `defaultValue` or `''`. Reported by `@gederer` on `#703`.
- Added ES build to allow tree-shaking 🌴 🌳 🌲 Thanks to `@xdissent` for PR `#937`.
- Shallow equal on `Field` and `FieldArray` `shouldComponentUpdate`. PR `#940` from `@leesiongchan`. Fixes `#936`, `#931`.
- Made smarter `hasErrors` logic. Fixes `#943`.
- Keep track of submit promise to fix multiple submit and async validation requests. `#829` `#888` 
#### Version 6.0.0-alpha.8
- **BUG** Fixed small typo bug. `#892` 
- **BUG** Fixed awkward bug that was not letting you clear a field value if it had been initialized. PR `#924` to fix `#879` 
- **BUG** Fixed infinite `deepEqual` loop, PR `#929` to fix `#919`
- **STABILITY** Migrated back to `lodash` for many common functional and looping functions. It's a small trade-off in bundle size in exchange for rock solid modules. Discussions on `#859`, `#890` and `#929`.
- **FEATURE** Implemented `getRenderedComponent()` on both `Field` and `FieldArray` to grant access to the rendered components. `#927` 
- **FEATURE** Implemented `destroyOnUnmount` config parameter. Works exactly as in `v5`.
- **FEATURE** Implemented [`shouldAsyncValidate`](http://redux-form.com/6.0.0-alpha.8/docs/api/ReduxForm.md/#-shouldasyncvalidate-params-boolean-optional-) config parameter to give library users full control over when async validation is run.

---
- **TESTING** `v6` now has ****100% test coverage****!! 🎉 👯  The last 0.5% were a slog.
#### Version 6.0.0-alpha.7
- **Field Arrays**     🎉 🎉 👯 
- Array-specific validation errors via the `_error` key on the array in the errors object. `#486` `#762` `#868` 
- [Flux Standard Action](https://github.com/acdlite/flux-standard-action) Compliance. All `redux-form` actions follow FSA. `#799` `#586` `#63` 
- RIP `bindActionData()`, you were a clever functional trick, but you added too much complexity.
- Stopped using `Object.values()`, which was causing problems. `#881` `#907` 
- Allowed rerender on non-`redux-form` prop changes. `#866` `#906` 
- New [Material UI Example](http://redux-form.com/6.0.0-alpha.7/examples/material-ui/), courtesy of `@mihirsoni`.
- And possibly most importantly, the performance of the [Field Arrays Example](http://redux-form.com/6.0.0-alpha.7/examples/fieldArrays) is _excellent_ even when you add many, many form fields. `#529` 
#### Breaking Change

Previous alpha versions allowed

``` js
<Field name="firstName" component={React.DOM.input}/>
```

After a discussion with `@gaearon` on `#871`, the new API is with just a string:

``` js
<Field name="firstName" component="input"/>
```
### Learning Field Arrays

The `FieldArray` component is pretty self-explanatory if you understand how to use the `Field` component. Check out the [Field Arrays Example](http://redux-form.com/6.0.0-alpha.7/examples/fieldArrays) and the [`FieldArray` docs](http://redux-form.com/6.0.0-alpha.7/docs/api/FieldArray.md/).

``` js
render() {
  return (
    <div>
      <FieldArray name="awards" component={awards =>
        <div>
          <ul>
            {awards.map((name, index) => <li key={index}>
              <label>Award #{index + 1}</label>
              <Field name={name} type="text" component="input"/>
              <button type="button" onClick={() => awards.remove(index)}>Remove Award</button>
            </li>}
          </ul>
          <button type="button" onClick={() => awards.push()}>Add Award</button>
        </div>
      }/>
    </div>
  )
}
```
#### Version 6.0.0-alpha.5
- Changed sync validation back to the way it was in `v5`. `#838` 
- Added `anyTouched` prop as suggested by `@andrewmclagan` on `#81` 
#### Version 6.0.0-alpha.4
# 🎉 🎉 IT'S HERE!!! 🎉 🎉
### What you should know
- Until stable launch, the code is in the `v6` branch (`https://github.com/erikras/redux-form/tree/v6`)
- Docs and examples are now in the primary branch (what will become `master` when `v6.0.0` is released)
- Each example is its own standalone webapp, so different examples can have different dependencies, e.g. ImmutableJS or third party UI libraries
- [Entirely new website](http://redux-form.com/6.0.0-alpha.4/), built from the ground up to be responsive and to showcase the exact examples and docs that are in GitHub. (This took a while.)
### What you should do
- Read the [Migration Guide](http://redux-form.com/6.0.0-alpha.4/docs/MigrationGuide.md) to understand the differences between `v5` and `v6` and get an idea of what your migration path looks like.
- Read the [API docs](http://redux-form.com/6.0.0-alpha.4/docs/api/), **especially [the docs for `Field`](http://redux-form.com/6.0.0-alpha.4/docs/api/Field.md/)**.
- Clone the `v6` branch (`https://github.com/erikras/redux-form/tree/v6`) and run the examples.
### How you can help
- Constructive comments, concerns, and suggestions are welcome.
- There are certain to be many typos, broken links, and other mistakes in the docs. PRs to correct those would be most appreciated. Issues informing me of them would also be appreciated, but less so. 😄 
- Please include the word "v6" in the title of issues or PRs about `v6`.

`v6` is not complete yet, but I wanted to get it out to you early to play around with and make suggestions.
### What is left to do
- Array fields
- Normalizing
- Responding to external events, the `plugin()` API from `v5`
- Probably more stuff I'm forgetting at the moment
- World Domination
