### PR TITLE
[Doppins] Upgrade dependency react-notification-system to 0.2.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "react-breadcrumbs": "1.3.16",
     "react-datepicker": "0.28.2",
     "react-dom": "15.1.0",
-    "react-notification-system": "0.2.7",
+    "react-notification-system": "0.2.10",
     "react-redux": "4.4.5",
     "react-router": "2.5.1",
     "redux": "3.5.2",


### PR DESCRIPTION
Hi!

A new version was just released of `react-notification-system`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded react-notification-system from `0.2.7` to `0.2.10`
#### Changelog:
#### Version 0.2.9
