### PR TITLE
[Doppins] Upgrade dependency axios to 0.15.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "webpack-hot-middleware": "~2.12.0"
   },
   "dependencies": {
-    "axios": "0.12.0",
+    "axios": "0.14.0",
     "draft-js": "0.7.0",
     "json-loader": "^0.5.4",
     "lodash": "4.13.1",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "webpack-hot-middleware": "~2.12.0"
   },
   "dependencies": {
-    "axios": "0.15.2",
+    "axios": "0.15.3",
     "draft-js": "0.7.0",
     "json-loader": "^0.5.4",
     "lodash": "4.13.1",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "webpack-hot-middleware": "~2.12.0"
   },
   "dependencies": {
-    "axios": "0.15.1",
+    "axios": "0.15.2",
     "draft-js": "0.7.0",
     "json-loader": "^0.5.4",
     "lodash": "4.13.1",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "webpack-hot-middleware": "~2.12.0"
   },
   "dependencies": {
-    "axios": "0.14.0",
+    "axios": "0.15.0",
     "draft-js": "0.7.0",
     "json-loader": "^0.5.4",
     "lodash": "4.13.1",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "webpack-hot-middleware": "~2.12.0"
   },
   "dependencies": {
-    "axios": "0.15.0",
+    "axios": "0.15.1",
     "draft-js": "0.7.0",
     "json-loader": "^0.5.4",
     "lodash": "4.13.1",


### PR DESCRIPTION
Hi!

A new version was just released of `axios`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded axios from `0.12.0` to `0.14.0`
#### Changelog:
#### Version 0.13.1
#### Version 0.13.0
#### Version 0.14.0
