### PR TITLE
[Doppins] Upgrade dependency node-sass to ~3.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "http-proxy-middleware": "~0.16.0",
     "jsonwebtoken": "~7.0.1",
     "node-libs-browser": "~1.0.0",
-    "node-sass": "~3.10.0",
+    "node-sass": "~3.10.1",
     "object-assign": "~4.1.0",
     "phantomjs-prebuilt": "~2.1.7",
     "postcss-loader": "~0.9.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "http-proxy-middleware": "~0.16.0",
     "jsonwebtoken": "~7.0.1",
     "node-libs-browser": "~1.0.0",
-    "node-sass": "~3.8.0",
+    "node-sass": "~3.9.3",
     "object-assign": "~4.1.0",
     "phantomjs-prebuilt": "~2.1.7",
     "postcss-loader": "~0.9.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "http-proxy-middleware": "~0.16.0",
     "jsonwebtoken": "~7.0.1",
     "node-libs-browser": "~1.0.0",
-    "node-sass": "~3.9.3",
+    "node-sass": "~3.10.0",
     "object-assign": "~4.1.0",
     "phantomjs-prebuilt": "~2.1.7",
     "postcss-loader": "~0.9.1",


### PR DESCRIPTION
Hi!

A new version was just released of `node-sass`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded node-sass from `~3.8.0` to `~3.9.3`
#### Changelog:
#### Version 3.9.3
## Fix filename issues 🚑

In v3.9.0 we began publishing our test suite to npm as part of our release. We did this be compliant with the node-citgm project. Being the citgm would give us early warning of changes in Node that would break Node Sass for users. We'd hoped this would allows to address these issue early and avoid the dozens of bug reports we receive.

However some users have experience issues with some test filenames include unicode characters. Some npm@2 users have also experienced issues with our path names being too long.

As a result we're temporarily reverting the addition of our test suite until we have a solution for these issues.
## We're sorry 💖

Noone ever wants to break someone's build. We had expected this minor change to be innocuous. 

Unfortunately we had not accounted for the variety of operating environments our +2M monthly downloads would be running on.  Although the number of affected users was small, the failure was at times catastrophic.

Having this feature is important to us, but not breaking your builds, and workflows is critical.
#### Version 3.9.0
## Installation improvements

Installation issues are a steady background noise of Node Sass. These issues are mostly to local environment issues that are simply out of control. These issue take up a lot of time so we've been trying to provide more useful output when an installation fails.

This release we focused on adding more visibility to the binary download process. NPM will now output when it begins to download the binary, where it's downloading the binary from, as well as progress bar. It's how hope that this additional transparency will allow users to self-diagnose local problems before opening an issue. 

The download progress bar respects npm's `progress` config flag.

We've also added a generous download timeout to prevent rare instances of installs hanging infinitely.

`@andyxxsd` `@xzyfer`, `#1695` `#1694` `#1691` 
## CI stability

Our CI has been growing increasingly flakey. After a lot of investigation the main culprit appears to `child_process.spawnSync` on Node 0.10.x. We've put some work arounds in place to increase the stability of our CI whilst maintaining test coverage.

`@nschonni` `@xzyfer`, `#1692` `#1697` 
## SASS_PATH support

You can now set the `SASS_PATH` environment variable to a colon delimited list of directories and Sass will automatically look in each of them when finding a file for `@import`. This is a little known feature of Ruby Sass which has been added to aid compatibility.

`@nottrobin`, `#1680`
### Misc
- Update troubleshooting guide with sample output (`@xzyfer`, `#1696`)
- Publish test to npm (`@xzyfer`, `#1688`)
- Update troubleshooting guide with instructions to check `COMSPEC` on Windows (`@saper`, 1673)
- Fix build errors with Electron (`@saper`, `#1631`)
- Fix issue with `libsass_ext` in node-gyp (`@saper`, `#1599`)
- Update CLI usage documentation for clarity (`@howlowck`, `#1593`)
- Update troubleshooting guide with simplified debugging steps (`@mohuk` , `#1586`)
- Convert JSHint to ESLint (`@nschonni`, `#1545`)
- Add an Issue template (`@nschonni`, `#1399`)
- Replace gitter badge with Slack  (`@xzyfer`)

---
#### Supported Environments

| OS | Architecture | Node |
| --- | --- | --- |
| Windows | x86 & x64 | 0.10, 0.12, 1, 2, 3, 4, 5, 6 |
| OSX | x64 | 0.10, 0.12, 1, 2, 3, 4, 5, 6 |
| Linux | x86 & x64 | 0.10, 0.12, 1, 2, 3, 4, 5, 6 |
| FreeBSD | i386 & amd64 | 0.10, 0.12, 1, 2, 3, 4, 5, 6 |

*Linux support refers to Ubuntu, Debian, and CentOS 5
