### PR TITLE
[Doppins] Upgrade dependency wdio-cucumber-framework to ~0.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "url-loader": "~0.5.7",
     "wd-selenium-hooks": "~0.1.0",
     "wdio": "~0.3.3",
-    "wdio-cucumber-framework": "~0.1.0",
+    "wdio-cucumber-framework": "~0.2.5",
     "wdio-junit-reporter": "~0.1.0",
     "wdio-sauce-service": "~0.2.2",
     "wdio-selenium-standalone-service": "~0.0.5",


### PR DESCRIPTION
Hi!

A new version was just released of `wdio-cucumber-framework`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded wdio-cucumber-framework from `~0.1.0` to `~0.2.5`
