### PR TITLE
[Doppins] Upgrade dependency webpack-dev-middleware to ~1.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "wdio-selenium-standalone-service": "~0.0.5",
     "webdriverio": "~4.1.1",
     "webpack": "~1.13.1",
-    "webpack-dev-middleware": "~1.8.2",
+    "webpack-dev-middleware": "~1.8.3",
     "webpack-hot-middleware": "~2.12.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "wdio-selenium-standalone-service": "~0.0.5",
     "webdriverio": "~4.1.1",
     "webpack": "~1.13.1",
-    "webpack-dev-middleware": "~1.8.3",
+    "webpack-dev-middleware": "~1.8.4",
     "webpack-hot-middleware": "~2.12.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "wdio-selenium-standalone-service": "~0.0.5",
     "webdriverio": "~4.1.1",
     "webpack": "~1.13.1",
-    "webpack-dev-middleware": "~1.8.0",
+    "webpack-dev-middleware": "~1.8.1",
     "webpack-hot-middleware": "~2.12.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "wdio-selenium-standalone-service": "~0.0.5",
     "webdriverio": "~4.1.1",
     "webpack": "~1.13.1",
-    "webpack-dev-middleware": "~1.8.1",
+    "webpack-dev-middleware": "~1.8.2",
     "webpack-hot-middleware": "~2.12.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "wdio-selenium-standalone-service": "~0.0.5",
     "webdriverio": "~4.1.1",
     "webpack": "~1.13.1",
-    "webpack-dev-middleware": "~1.6.1",
+    "webpack-dev-middleware": "~1.7.0",
     "webpack-hot-middleware": "~2.12.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "wdio-selenium-standalone-service": "~0.0.5",
     "webdriverio": "~4.1.1",
     "webpack": "~1.13.1",
-    "webpack-dev-middleware": "~1.7.0",
+    "webpack-dev-middleware": "~1.8.0",
     "webpack-hot-middleware": "~2.12.0"
   },
   "dependencies": {


### PR DESCRIPTION
Hi!

A new version was just released of `webpack-dev-middleware`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded webpack-dev-middleware from `~1.6.1` to `~1.7.0`
