### PR TITLE
Enable admins to set trip status freely

### DIFF
--- a/src/sections/admin/trips/trip/tripStatus.jsx
+++ b/src/sections/admin/trips/trip/tripStatus.jsx
@@ -9,7 +9,7 @@ import Form from '../../../../commons/Form';
 import Segment from '../../../../commons/Segment';
 import Button from '../../../../commons/Button';
 import TripInfo from '../../../../commons/trip/tripInfo';
-import { TRIP_STATUSES } from '../../../../constants';
+import { TRIP_STATUSES, USER_ROLES } from '../../../../constants';
 import { retrieve, update } from '../../../../actions/tripActions';
 import { pushNotification } from '../../../../actions/notificationActions';
 
@@ -77,7 +77,19 @@ class UpdateTripStatus extends Component {
         return defaultValue;
     }
 
+    createSelectOptionsForAdmin() {
+        const options = [];
+        const statuses = Object.keys(TRIP_STATUSES);
+        _.forEach(statuses, value => {
+            options.push(this.createSelectObject(value));
+        });
+        return options;
+    }
+
     allowedActions(status) {
+        if (this.props.user.role === USER_ROLES.ADMIN) {
+            return this.createSelectOptionsForAdmin();
+        }
         const statuses = [this.createSelectObject(TRIP_STATUSES.CLOSED)];
         switch (status) {
         case TRIP_STATUSES.PENDING:
@@ -193,6 +205,7 @@ class UpdateTripStatus extends Component {
 
 UpdateTripStatus.propTypes = {
     trip: PropTypes.object,
+    user: PropTypes.object.isRequired,
     onSubmit: PropTypes.func,
     params: PropTypes.object.isRequired,
     dispatch: PropTypes.func.isRequired,


### PR DESCRIPTION
## At a glance
- A admin can now set the trip status to whatever they want
## References

See [DIH-407](https://jira.capraconsulting.no/browse/DIH-407)
