### PR TITLE
[Doppins] Upgrade dependency autoprefixer to ~6.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/capraconsulting/dih-webapp#readme",
   "devDependencies": {
-    "autoprefixer": "~6.5.0",
+    "autoprefixer": "~6.5.1",
     "babel-cli": "~6.10.1",
     "babel-core": "~6.10.4",
     "babel-loader": "~6.2.4",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/capraconsulting/dih-webapp#readme",
   "devDependencies": {
-    "autoprefixer": "~6.4.0",
+    "autoprefixer": "~6.5.0",
     "babel-cli": "~6.10.1",
     "babel-core": "~6.10.4",
     "babel-loader": "~6.2.4",


### PR DESCRIPTION
Hi!

A new version was just released of `autoprefixer`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded autoprefixer from `~6.4.0` to `~6.5.0`
#### Changelog:
#### Version 6.5.0

<img src="https://cloud.githubusercontent.com/assets/19343/18866736/ec7242d4-84a9-11e6-9761-749be98f2769.png" width="200" height="249" align="right" alt="The Lesser Arms of the German Empire, 1871 - 1918">

Autoprefixer 6.5 brings `defaults` keyword and fixes Grid support.
## `defaults`

Autoprefixer 6.5 includes [Browserslist](https://github.com/ai/browserslist) 1.4 with `defaults` keyword. So now you could extend default browsers list:

``` js
postcss([
  autoprefixer({ browsers: ['defaults', 'ie 9'] })
])
```

Also don’t miss new tool to check what browsers will be picked by Browserslist: [browserl.ist](http://browserl.ist/).
## CSS Grid Layout

With Autoprefixer small subset of coming CSS Grid Layout will works in IE by adding a `-ms-` prefix and change the syntax (as we do for Flexbox). In 6.5 we fixed some cases with `-ms-grid-row-align`.

``` css
.container {
    display: grid;
    grid-template-columns: auto 1fr;
}
.element {
    align-self: stretch;
    grid-column-start: 1;
    grid-column-end: span 3;
}
```

``` css
.container {
    display: -ms-grid;
    display: grid;
    -ms-grid-columns: auto 1fr;
    grid-template-columns: auto 1fr;
}
.element {
    -ms-grid-row-align: stretch;
    align-self: stretch;
    -ms-grid-column: 1;
    grid-column-start: 1;
    -ms-grid-column-span: 3;
    grid-column-end: span 3;
}
```
## Flexbox

`align-self` has same syntax in final and 2009 Flexbox specification.

In 6.5 we fixed when Autopefixer removed `-webkit-align-self` even if final spec is still in requirements.
