### PR TITLE
[Doppins] Upgrade dependency chai-as-promised to ~6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "babel-preset-stage-0": "~6.5.0",
     "bluebird": "^3.4.1",
     "chai": "~3.5.0",
-    "chai-as-promised": "~5.3.0",
+    "chai-as-promised": "~6.0.0",
     "copy-webpack-plugin": "~3.0.1",
     "css-loader": "~0.23.1",
     "cucumber": "~0.10.2",


### PR DESCRIPTION
Hi!

A new version was just released of `chai-as-promised`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded chai-as-promised from `~5.3.0` to `~6.0.0`
