### PR TITLE
[Doppins] Upgrade dependency babel-plugin-transform-object-rest-spread to ~6.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "babel-cli": "~6.10.1",
     "babel-core": "~6.10.4",
     "babel-loader": "~6.2.4",
-    "babel-plugin-transform-object-rest-spread": "~6.8.0",
+    "babel-plugin-transform-object-rest-spread": "~6.16.0",
     "babel-preset-es2015": "~6.9.0",
     "babel-preset-react": "~6.11.1",
     "babel-preset-stage-0": "~6.5.0",


### PR DESCRIPTION
Hi!

A new version was just released of `babel-plugin-transform-object-rest-spread`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded babel-plugin-transform-object-rest-spread from `~6.8.0` to `~6.16.0`
