### PR TITLE
[Doppins] Upgrade dependency babel-preset-stage-0 to ~6.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "babel-plugin-transform-object-rest-spread": "~6.8.0",
     "babel-preset-es2015": "~6.9.0",
     "babel-preset-react": "~6.11.1",
-    "babel-preset-stage-0": "~6.5.0",
+    "babel-preset-stage-0": "~6.16.0",
     "bluebird": "^3.4.1",
     "chai": "~3.5.0",
     "chai-as-promised": "~5.3.0",


### PR DESCRIPTION
Hi!

A new version was just released of `babel-preset-stage-0`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded babel-preset-stage-0 from `~6.5.0` to `~6.16.0`
