### PR TITLE
[Doppins] Upgrade dependency babel-preset-react to ~6.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "babel-loader": "~6.2.4",
     "babel-plugin-transform-object-rest-spread": "~6.8.0",
     "babel-preset-es2015": "~6.9.0",
-    "babel-preset-react": "~6.11.1",
+    "babel-preset-react": "~6.16.0",
     "babel-preset-stage-0": "~6.5.0",
     "bluebird": "^3.4.1",
     "chai": "~3.5.0",


### PR DESCRIPTION
Hi!

A new version was just released of `babel-preset-react`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded babel-preset-react from `~6.11.1` to `~6.16.0`
