### PR TITLE
[Doppins] Upgrade dependency draft-js-import-html to ^0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   "dependencies": {
     "axios": "0.12.0",
     "draft-js": "0.7.0",
-    "draft-js-import-html": "^0.2.2",
+    "draft-js-import-html": "^0.3.0",
     "json-loader": "^0.5.4",
     "lodash": "4.13.1",
     "moment": "2.13.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   "dependencies": {
     "axios": "0.12.0",
     "draft-js": "0.7.0",
-    "draft-js-import-html": "^0.3.0",
+    "draft-js-import-html": "^0.3.2",
     "json-loader": "^0.5.4",
     "lodash": "4.13.1",
     "moment": "2.13.0",


### PR DESCRIPTION
Hi!

A new version was just released of `draft-js-import-html`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded draft-js-import-html from `^0.2.2` to `^0.3.0`
