### PR TITLE
[Doppins] Upgrade dependency react-breadcrumbs to 1.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "raven-js": "3.3.0",
     "react": "15.1.0",
     "react-addons-update": "15.1.0",
-    "react-breadcrumbs": "1.3.16",
+    "react-breadcrumbs": "1.5.0",
     "react-datepicker": "0.28.2",
     "react-dom": "15.1.0",
     "react-notification-system": "0.2.7",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "raven-js": "3.3.0",
     "react": "15.1.0",
     "react-addons-update": "15.1.0",
-    "react-breadcrumbs": "1.5.0",
+    "react-breadcrumbs": "1.5.2",
     "react-datepicker": "0.28.2",
     "react-dom": "15.1.0",
     "react-notification-system": "0.2.7",


### PR DESCRIPTION
Hi!

A new version was just released of `react-breadcrumbs`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded react-breadcrumbs from `1.3.16` to `1.5.0`

