### PR TITLE
Disallow null value for trip signup

### DIFF
--- a/src/sections/trips/signup/SignupTripForm.jsx
+++ b/src/sections/trips/signup/SignupTripForm.jsx
@@ -76,9 +76,7 @@ function SignupTripForm(props) {
                     label="Destination"
                     icon="marker"
                     values={props.destinations}
-                    nullValue="No destination preference"
                     placeholder="Select a destination"
-                    allowNullValue
                     valueLabel="name"
                     valueKey="id"
                     onChange={(destination) => {


### PR DESCRIPTION
* Remove nullvalue text and allowNulVallue property on destination selection field in trip signup. This means user has to select destination.

## Screenshots
__Before:__
![image](https://cloud.githubusercontent.com/assets/1620267/20860409/beafef1a-b977-11e6-859d-ab318c2b45a7.png)


__Now:__
![image](https://cloud.githubusercontent.com/assets/1620267/20860395/4a24925e-b977-11e6-982e-d8a7c76a6f3f.png)


## References
See [DIH-412](https://jira.capraconsulting.no/browse/DIH-412)