### PR TITLE
Admin volunteer add sets trip status to accepted

### DIFF
--- a/src/sections/admin/destinations/destination/addVolunteer.jsx
+++ b/src/sections/admin/destinations/destination/addVolunteer.jsx
@@ -47,7 +47,7 @@ class AddVolunteer extends Component {
             endDate: data.endDate,
             wishStartDate: data.startDate, // Cannot be null. Not used.
             destinationId: this.props.params.destinationId,
-            status: TRIP_STATUSES.PENDING,
+            status: TRIP_STATUSES.ACCEPTED,
             notes: data.notes
         };
         this.handlers.create(alteredData)


### PR DESCRIPTION
## At a glance
When an admin adds a volunteer to a destination, the status of that trip will now be "ACCEPTED" instead of "PENDING"

## References
See [DIH-388](https://jira.capraconsulting.no/browse/DIH-388)