### PR TITLE
Add validation for destinationId in trip signup

### DIFF
--- a/src/sections/trips/signup/SignupTripForm.jsx
+++ b/src/sections/trips/signup/SignupTripForm.jsx
@@ -17,6 +17,7 @@ const validate = values => { // eslint-disable-line
     if (values.endDate && values.startDate > values.endDate) {
         errors.endDate = 'Must be a date after the start date';
     }
+    if (!values.destinationId) errors.destinationId = 'You have to select a destination';
     return errors;
 };
 


### PR DESCRIPTION
## At a gance
Adds validation to destination-field in trip signup so users no longer can have "No preference"/`null` as their destination. DIH wanted this option completely removed, but the missing validation enabled users to simply not select a destination.

## References
See [DIH-432](https://jira.capraconsulting.no/browse/DIH-432)