### PR TITLE
Enable user deletion for admins

### DIFF
--- a/src/commons/user/deleteUser.jsx
+++ b/src/commons/user/deleteUser.jsx
@@ -24,10 +24,18 @@ function DeleteUser(props) {
                 handleSubmit={handleSubmit}
             >
                 <ToggleField
-                    name="I confirm that I want to delete my account"
-                    label={`Deleting your account means that you will have to register again
-                    if you want to go on a new trip. Toggling this button and confirming will
-                    delete your account, and log you out.`}
+                    name={!props.showAdminFields ? 'I confirm that I want to delete my account'
+                        : 'Confirm that you want to delete this account'
+                    }
+                    label={!props.showAdminFields ?
+                        `Deleting your account means that you will have to register again
+                        if you want to go on a new trip. Toggling this button and confirming will
+                        delete your account, and log you out.`
+                        : `Deleting an account means that the user will have to register again
+                        if he/she wants to go on a new trip. Toggling this button and confirming
+                        will delete this account. The system will send the user a short
+                        email informing about the change.`
+                    }
                     id="isActive"
                 >
                     {isActive}

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -110,7 +110,11 @@ export default(
                     <Route path=":destinationId" component={Destination}>
                         <IndexRoute component={DestinationVolunteers} />
                         <Route name="Edit destination" path="edit" component={EditDestination} />
-                        <Route name="Emails" path="emails" component={DestinationEmails} />
+                        <Route
+                            name="Destination emails"
+                            path="emails"
+                            component={DestinationEmails}
+                        />
                         <Route
                             name="Add volunteer"
                             path="addvolunteer"
@@ -128,8 +132,9 @@ export default(
                     <IndexRoute component={Users} />
                     <Route path=":userId" component={User}>
                         <IndexRoute component={ViewUser} />
-                        <Route name="Edit" path="edit" component={EditUser} />
-                        <Route name="Trips" path="trips" component={TripsForUser} />
+                        <Route name="Edit user" path="edit" component={EditUser} />
+                        <Route name="Delete user" path="delete" component={DeleteUser} />
+                        <Route name="See user trips" path="trips" component={TripsForUser} />
                     </Route>
                 </Route>
 

--- a/src/sections/admin/users/user/index.jsx
+++ b/src/sections/admin/users/user/index.jsx
@@ -46,6 +46,10 @@ class User extends Component {
                     uri: `/admin/users/${this.props.params.userId}/edit`
                 },
                 {
+                    name: 'Delete',
+                    uri: `/admin/users/${this.props.params.userId}/delete`
+                },
+                {
                     name: 'Trips',
                     uri: `/admin/users/${this.props.params.userId}/trips`
                 }
@@ -62,6 +66,19 @@ class User extends Component {
 
     onUpdate(user) {
         const userId = parseInt(this.props.params.userId, 10);
+
+        if (user.isActive !== 'undefined'
+        && user.isActive !== null
+        && user.isActive) {
+            // Check if isActive is defined and set to true
+            // Because it's inverted before it's handed to views
+            // So that the toggle works as we want in DeleteUser
+            this.handlers.update({ ...user, id: userId, isActive: false })
+            .then(() => this.handlers.notification('The user profile is deleted', 'success'))
+            .then(() => browserHistory.push('/admin/users'));
+            return;
+        }
+
         this.handlers.update({ id: userId, ...user })
             .then(response => {
                 const message = 'User changes saved!';
@@ -78,7 +95,11 @@ class User extends Component {
     }
 
     prepareInitialValues(user) {
-        return { ...user, birth: moment(user.birth).format('YYYY-MM-DD') };
+        return {
+            ...user,
+            birth: moment(user.birth).format('YYYY-MM-DD'),
+            isActive: !user.isActive // Inverted to work with form toggle
+        };
     }
 
     render() {


### PR DESCRIPTION
## At a glance
Enabling admin user deletion by

* Creating a route `/admin/users/:id/delete` and adding a corresponding tab in admin user view.
* Changing common `deleteUser`-component so that its messages are different in the admin context
* Changing the update user implementation for admin, so that the needed inverted value of the `isActive` field is maintained. The inverted value is needed so that the `TogggleField` can work.

## Screenshot
![image](https://cloud.githubusercontent.com/assets/1620267/22182573/bdbd5dc4-e0a8-11e6-9b74-c690db1d1a9b.png)


## References
See [DIH-419](https://jira.capraconsulting.no/browse/DIH-419)