### PR TITLE
Made tables presistent

### DIFF
--- a/.lgtm
+++ b/.lgtm
@@ -1,2 +1,0 @@
-approvals = 2
-pattern = "(?i):shipit:|:\\+1:|LGTM"

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "lodash": "4.13.1",
     "moment": "2.13.0",
     "normalize.css": "4.2.0",
+    "qs": "^6.3.0",
     "raven-js": "3.3.0",
     "react": "15.1.0",
     "react-addons-update": "15.1.0",

--- a/src/commons/adminTripTable/index.jsx
+++ b/src/commons/adminTripTable/index.jsx
@@ -40,6 +40,7 @@ class AdminTripTable extends Component {
                 <TripsTable
                     trips={this.props.trips}
                     userId={this.props.userId}
+                    location={this.props.location}
                     destinationId={this.props.destinationId}
                     role={this.props.role}
                     isAdmin
@@ -58,6 +59,7 @@ AdminTripTable.propTypes = {
     trips: PropTypes.array.isRequired,
     dispatch: PropTypes.func.isRequired,
     userId: PropTypes.number,
+    location: PropTypes.object,
     destinationId: PropTypes.number,
     role: PropTypes.string,
     statuses: PropTypes.array

--- a/src/commons/adminTripTable/tripsTable.jsx
+++ b/src/commons/adminTripTable/tripsTable.jsx
@@ -167,6 +167,7 @@ class TripsTable extends Component {
         return (
             <Table
                 search
+                location={this.props.location}
                 responsivePriority={[
                     'fullName',
                     'destination',
@@ -202,6 +203,7 @@ TripsTable.propTypes = {
     destinationId: PropTypes.number,
     role: PropTypes.string,
     statuses: PropTypes.array,
+    location: PropTypes.object,
     isAdmin: PropTypes.bool
 };
 

--- a/src/commons/table/dateFilter.jsx
+++ b/src/commons/table/dateFilter.jsx
@@ -44,7 +44,7 @@ class DateFilter extends Component {
 
     render() {
         const { date, datePrefix } = this.props;
-
+        console.log(date);
         let label = `${this.props.datePrefix} date`;
         if (date) label = `${datePrefix}: ${date.format('YYYY-MM-DD')}`;
 

--- a/src/commons/table/dateInterval.jsx
+++ b/src/commons/table/dateInterval.jsx
@@ -1,19 +1,21 @@
 import React, { Component, PropTypes } from 'react';
+import moment from 'moment';
 import DateFilter from './dateFilter';
 
 class DateInterval extends Component {
     constructor(props) {
         super(props);
+
         this.state = {
-            fromDate: null,
-            toDate: null
+            fromDate: this.props.fromDate ? moment(this.props.fromDate) : null,
+            toDate: this.props.toDate ? moment(this.props.toDate) : null
         };
     }
 
     updateDate(date, field) {
         const data = {
-            fromDate: this.state.fromDate,
-            toDate: this.state.toDate
+            fromDate: this.state.fromDate || null,
+            toDate: this.state.toDate || null
         };
         this.setState({ [field]: date });
         data[field] = date;
@@ -41,6 +43,8 @@ class DateInterval extends Component {
 }
 
 DateInterval.propTypes = {
+    fromDate: PropTypes.String,
+    toDate: PropTypes.String,
     onChange: PropTypes.func.isRequired
 };
 

--- a/src/commons/table/filter.jsx
+++ b/src/commons/table/filter.jsx
@@ -5,7 +5,7 @@ class Filter extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            activeFilter: null,
+            activeFilter: this.props.value || null,
             visible: false,
             active: false
         };
@@ -131,6 +131,7 @@ class Filter extends Component {
 
 Filter.propTypes = {
     filters: PropTypes.array.isRequired,
+    value: PropTypes.object,
     onChange: PropTypes.func.isRequired
 };
 

--- a/src/sections/admin/destinations/destinationsTable.jsx
+++ b/src/sections/admin/destinations/destinationsTable.jsx
@@ -61,6 +61,7 @@ class DestinationsList extends Component {
                     search
                     loading={this.state.loading}
                     filters={this.filters}
+                    location={this.props.location}
                     emptyState={{
                         title: 'No destinations',
                         message: 'Could not find any destinations.'
@@ -103,6 +104,7 @@ const mapStateToProps = store => ({
 
 DestinationsList.propTypes = {
     dispatch: PropTypes.func.isRequired,
+    location: PropTypes.object.isRequired,
     destinations: PropTypes.array.isRequired
 };
 

--- a/src/sections/admin/trips/allTrips.jsx
+++ b/src/sections/admin/trips/allTrips.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import AdminTripTable from '../../../commons/adminTripTable';
 
-const AllTrips = () => (<AdminTripTable />);
+const AllTrips = (props) => (<AdminTripTable location={props.location} />);
 
 export default AllTrips;

--- a/src/sections/admin/users/index.jsx
+++ b/src/sections/admin/users/index.jsx
@@ -96,6 +96,7 @@ class UsersTableContainer extends Component {
                         search
                         select
                         loading={this.state.loading}
+                        location={this.props.location}
                         emptyState={{
                             title: 'No users',
                             message: 'Could not find any users.'
@@ -141,7 +142,8 @@ const mapStateToProps = store => ({
 
 UsersTableContainer.propTypes = {
     dispatch: PropTypes.func.isRequired,
-    users: PropTypes.array.isRequired
+    users: PropTypes.array.isRequired,
+    location: PropTypes.object
 };
 
 export default connect(mapStateToProps)(UsersTableContainer);


### PR DESCRIPTION
## At a glance

Makes the tables thats given the param `location={this.props.location}` presist its filters, sort and search, so that the user doesnt have to redo this several times.

## References
See [DIH-421](https://jira.capraconsulting.no/browse/DIH-421)